### PR TITLE
#5 Use containers to make modifications to images

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/curie.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/curie.xcscheme
@@ -136,6 +136,10 @@
             argument = "ls"
             isEnabled = "NO">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "ls -c"
+            isEnabled = "NO">
+         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction

--- a/Sources/CurieCommand/Commands/ListCommand.swift
+++ b/Sources/CurieCommand/Commands/ListCommand.swift
@@ -10,6 +10,12 @@ struct ListCommand: Command {
         abstract: "List images."
     )
 
+    @Flag(
+        name: .shortAndLong,
+        help: "List containers."
+    )
+    var containers: Bool = false
+
     @Option(
         name: .shortAndLong,
         help: "Format \"text\" or \"json\" (\"text\" by default).",
@@ -28,6 +34,7 @@ struct ListCommand: Command {
 
         func execute(command: ListCommand) throws {
             try interactor.execute(with: .init(
+                listContainers: command.containers,
                 format: parseFormat(command)
             ))
         }

--- a/Sources/CurieCore/Cache/ImageReference.swift
+++ b/Sources/CurieCore/Cache/ImageReference.swift
@@ -2,8 +2,8 @@ import CurieCommon
 import Foundation
 
 enum ImageType {
-    case ephemeral
-    case persistent
+    case container
+    case image
 }
 
 struct ImageDescriptor: Equatable {


### PR DESCRIPTION
- Changed the behaviour of `start` command. Now it creates a container with new identifier, once the container is closed, the changes will be move the the referenced image.
- Added `ls -c` command to list containers.

Test Plan:
- Ensure all CI checks pass
- Create new image, call `curie start <image id>`, in separate console verify `curie ls -c` shows the container. Close the container, verify `curie ls -c` does now show any containers. Call `curie ls` and verify the id of the original image changed as well as its content.