### PR TITLE
Don't display apra in `inspect` output if empty

### DIFF
--- a/Sources/CurieCore/Interactors/InspectInteractor.swift
+++ b/Sources/CurieCore/Interactors/InspectInteractor.swift
@@ -84,22 +84,25 @@ private struct Item: Codable {
 extension Item: CustomStringConvertible {
     var description: String {
         """
-        \(info.description)
-        \(arpa.description)
-
+        \(info.description)\(arpa.description)
         """
     }
 }
 
 extension [ARPARow] {
     var description: String {
-        """
+        guard !isEmpty else {
+            return ""
+        }
+        return """
+
         ARPA:
         \(
             enumerated()
                 .map { $1.description }
                 .joined(separator: "\n")
         )
+
         """
     }
 }


### PR DESCRIPTION
Test Plan:
- Ensure all CI checks pass