### PR TITLE
Use arp -an

### DIFF
--- a/Sources/CurieCore/Interactors/InspectInteractor.swift
+++ b/Sources/CurieCore/Interactors/InspectInteractor.swift
@@ -47,11 +47,11 @@ final class DefaultInspectInteractor: InspectInteractor {
         let reference = try imageCache.findReference(context.reference)
         let bundle = VMBundle(path: imageCache.path(to: reference))
         let info = try bundleParser.readInfo(from: bundle)
-        let arpa = try aprClient.executeARPA()
+        let arpItems = try aprClient.executeARPQuery()
         let macAddresses = Set(info.state.network.flatMap { $0.devices.map(\.value.MACAddress) } ?? [])
-        let filteredArpaRows = arpa.filter { macAddresses.contains($0.macAddress) }
+        let filteredArpaRows = arpItems.filter { macAddresses.contains($0.macAddress) }
 
-        let item = Item(info: info, arpa: filteredArpaRows)
+        let item = Item(info: info, arp: filteredArpaRows)
 
         switch context.format {
         case .text:
@@ -78,25 +78,25 @@ final class DefaultInspectInteractor: InspectInteractor {
 
 private struct Item: Codable {
     var info: VMInfo
-    var arpa: [ARPARow]
+    var arp: [ARPItem]
 }
 
 extension Item: CustomStringConvertible {
     var description: String {
         """
-        \(info.description)\(arpa.description)
+        \(info.description)\(arp.description)
         """
     }
 }
 
-extension [ARPARow] {
+extension [ARPItem] {
     var description: String {
         guard !isEmpty else {
             return ""
         }
         return """
 
-        ARPA:
+        ARP:
         \(
             enumerated()
                 .map { $1.description }
@@ -107,7 +107,7 @@ extension [ARPARow] {
     }
 }
 
-extension ARPARow: CustomStringConvertible {
+extension ARPItem: CustomStringConvertible {
     var description: String {
         """
           macAddress: \(macAddress)

--- a/Sources/CurieCore/Utils/ARPClient.swift
+++ b/Sources/CurieCore/Utils/ARPClient.swift
@@ -1,13 +1,13 @@
 import CurieCommon
 import Foundation
 
-struct ARPARow: Equatable, Codable {
+struct ARPItem: Equatable, Codable {
     let ip: String
     let macAddress: String
 }
 
 protocol ARPClient {
-    func executeARPA() throws -> [ARPARow]
+    func executeARPQuery() throws -> [ARPItem]
 }
 
 final class DefaultARPClient: ARPClient {
@@ -17,21 +17,21 @@ final class DefaultARPClient: ARPClient {
         self.system = system
     }
 
-    func executeARPA() throws -> [ARPARow] {
+    func executeARPQuery() throws -> [ARPItem] {
         let captureOutput = CaptureOutput()
-        try system.execute(["arp", "-a"], output: .custom(captureOutput))
+        try system.execute(["arp", "-an"], output: .custom(captureOutput))
 
         let tokens = captureOutput.outputString
             .split(separator: "\n")
             .map { $0.split(separator: " ") }
 
-        let items: [ARPARow] = tokens
+        let items: [ARPItem] = tokens
             .filter { $0.count >= 4 }
             .compactMap {
                 guard let macAddress = parseMAC(raw: $0[3]) else {
                     return nil
                 }
-                return ARPARow(
+                return ARPItem(
                     ip: parseIP(raw: $0[1]),
                     macAddress: macAddress
                 )


### PR DESCRIPTION
Use `arp -an` to query IP address for synthesised MAC addresses, it's much faster. Kudos to @tomekjarosik who spotted this issue and suggested the fix.

Test Plan:
- Ensure all CI checks pass
- Verify `curie inspect <container-reference>` result includes IP address(es).