### PR TITLE
Use full range of locally administrated MAC addresses

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -23,6 +23,7 @@ identifier_name:
     - GB
     - id
     - ip
+    - i
 
 type_name:
   excluded:

--- a/Sources/CurieCore/VM/VMConfigurator.swift
+++ b/Sources/CurieCore/VM/VMConfigurator.swift
@@ -237,7 +237,7 @@ final class DefaultVMConfigurator: VMConfigurator {
         (0 ..< 6)
             .map { i in
                 let value = UInt8.random(in: UInt8.min ..< UInt8.max)
-                return i == 0 ? value & 2 : value
+                return i == 0 ? value | 2 : value
             }
             .map { String(format: "%02X", $0) }
             .map { $0.lowercased() }


### PR DESCRIPTION
Test Plan:
- Ensure all CI checks pass
- Start a container with synthesized MAC address multiple times, ensure all generated MAC addresses are locally administered (https://en.wikipedia.org/wiki/MAC_address#Ranges_of_group_and_locally_administered_addresses)