### PR TITLE
Ensure repository name can contain colons

### DIFF
--- a/Sources/CurieCore/Cache/ImageCache.swift
+++ b/Sources/CurieCore/Cache/ImageCache.swift
@@ -223,11 +223,11 @@ final class DefaultImageCache: ImageCache {
 
     @discardableResult
     private func removeEmptySubdirectories(of path: AbsolutePath) throws -> Bool {
-        let list = try fileSystem.list(at: path)
-
         guard fileSystem.exists(at: path) else {
             return true
         }
+
+        let list = try fileSystem.list(at: path)
 
         let directories = list.compactMap {
             if case let .directory(directory) = $0 {

--- a/Sources/CurieCore/Cache/ImageReference.swift
+++ b/Sources/CurieCore/Cache/ImageReference.swift
@@ -16,16 +16,13 @@ struct ImageDescriptor: Equatable {
     }
 
     init(reference: String) throws {
-        let split = reference.split(separator: ":")
-        if split.count == 1 {
-            self = .init(repository: String(split[0]), tag: nil)
-            return
+        if let index = reference.lastIndex(of: ":") {
+            let repository = String(reference.prefix(upTo: index))
+            let tag = String(reference.suffix(from: reference.index(after: index)))
+            self = .init(repository: repository, tag: !tag.isEmpty ? tag : nil)
+        } else {
+            self = .init(repository: reference, tag: nil)
         }
-        if split.count == 2 {
-            self = .init(repository: String(split[0]), tag: String(split[1]))
-            return
-        }
-        throw CoreError.generic("Invalid reference '\(reference)'")
     }
 }
 

--- a/Sources/CurieCoreTests/Utils/ARPClientTests.swift
+++ b/Sources/CurieCoreTests/Utils/ARPClientTests.swift
@@ -31,7 +31,7 @@ final class DefaultARPClientTests: XCTestCase {
         """
 
         // When
-        let rows = try subject.executeARPA()
+        let rows = try subject.executeARPQuery()
 
         // Then
         XCTAssertEqual(


### PR DESCRIPTION
- Fixed unit tests (sadly they are still not running on CI)
- Fixed cleanup when `containers` directory does not exist

Test Plan:
- Ensure all CI checks pass
- Clone image so the new reference contain multiple colons, e.g. `myservice.com:2828/test/image:2.0`, verify the new image is created with name `myservice.com:2828/test/image` and tag `2.0`.
