### PR TITLE
Change `start` to start existing containers

### DIFF
--- a/Sources/CurieCommand/Commands/StartCommand.swift
+++ b/Sources/CurieCommand/Commands/StartCommand.swift
@@ -7,7 +7,7 @@ import TSCBasic
 struct StartCommand: Command {
     static let configuration: CommandConfiguration = .init(
         commandName: "start",
-        abstract: "Start a container to modify the image."
+        abstract: "Start a stopped container."
     )
 
     @Argument(help: "Reference \(CurieCore.Constants.referenceFormat).")

--- a/Sources/CurieCore/Cache/ImageCache.swift
+++ b/Sources/CurieCore/Cache/ImageCache.swift
@@ -173,7 +173,7 @@ final class DefaultImageCache: ImageCache {
             switch type {
             case .container:
                 guard let image = try listContainers().first(where: { $0.reference.id.description == reference }) else {
-                    throw CoreError.generic("Cannot find the image")
+                    throw CoreError.generic("Cannot find the container")
                 }
                 return image.reference
             case .image:

--- a/Sources/CurieCore/Interactors/StartInteractor.swift
+++ b/Sources/CurieCore/Interactors/StartInteractor.swift
@@ -44,24 +44,12 @@ public final class DefaultStartInteractor: StartInteractor {
     }
 
     public func execute(with context: StartInteractorContext) throws {
-        console.text("Start image \(context.reference)")
+        console.text("Start \(context.reference) container")
 
-        let sourceReference = try imageCache.findImageReference(context.reference)
-        let targetReference = try imageCache.cloneImage(source: sourceReference, target: .ephemeral)
+        let sourceReference = try imageCache.findContainerReference(context.reference)
 
-        let bundle = VMBundle(path: imageCache.path(to: targetReference))
+        let bundle = VMBundle(path: imageCache.path(to: sourceReference))
         let vm = try configurator.loadVM(with: bundle)
-
-        vm.events
-            .filter { $0 == .imageDidStop || $0 == .imageStopFailed }
-            .sink { [imageCache, console] _ in
-                do {
-                    try imageCache.moveImage(source: targetReference, target: sourceReference)
-                } catch {
-                    console.error(error.localizedDescription)
-                }
-            }
-            .store(in: &cancellables)
 
         try imageRunner.run(vm: vm, bundle: bundle, noWindow: context.noWindow)
     }


### PR DESCRIPTION
Test Plan:
- Ensure all CI checks pass
- Create a new container, then verify the container can be started via `curie start <reference>`