### PR TITLE
Add `commit` command

### DIFF
--- a/Sources/CurieCommand/Command+Setup.swift
+++ b/Sources/CurieCommand/Command+Setup.swift
@@ -6,10 +6,11 @@ import Foundation
 private enum Setup {
     static let allSubcommands: [(ParsableCommand.Type, Assembly)] = [
         (BuildCommand.self, BuildCommand.Assembly()),
-        (CreateCommand.self, CreateCommand.Assembly()),
-        (ListCommand.self, ListCommand.Assembly()),
-        (InspectCommand.self, InspectCommand.Assembly()),
         (CloneCommand.self, CloneCommand.Assembly()),
+        (CreateCommand.self, CreateCommand.Assembly()),
+        (CommitCommand.self, CommitCommand.Assembly()),
+        (InspectCommand.self, InspectCommand.Assembly()),
+        (ListCommand.self, ListCommand.Assembly()),
         (RemoveCommand.self, RemoveCommand.Assembly()),
         (RunCommand.self, RunCommand.Assembly()),
         (StartCommand.self, StartCommand.Assembly()),

--- a/Sources/CurieCommand/Commands/CommitCommand.swift
+++ b/Sources/CurieCommand/Commands/CommitCommand.swift
@@ -1,0 +1,46 @@
+import ArgumentParser
+import CurieCommon
+import CurieCore
+import Foundation
+import TSCBasic
+
+struct CommitCommand: Command {
+    static let configuration: CommandConfiguration = .init(
+        commandName: "commit",
+        abstract: "Create a new image from a container's changes."
+    )
+
+    @Argument(help: "Container reference \(CurieCore.Constants.referenceFormat).")
+    var containerReference: String
+
+    @Argument(help: "Image reference \(CurieCore.Constants.referenceFormat).")
+    var imageReference: String?
+
+    final class Executor: CommandExecutor {
+        private let interactor: CommitInteractor
+        private let console: Console
+
+        init(interactor: CommitInteractor, console: Console) {
+            self.interactor = interactor
+            self.console = console
+        }
+
+        func execute(command: CommitCommand) throws {
+            try interactor.execute(with: .init(
+                containerReference: command.containerReference,
+                imageReference: command.imageReference
+            ))
+        }
+    }
+
+    final class Assembly: CommandAssembly {
+        func assemble(_ registry: Registry) {
+            registry.register(Executor.self) { r in
+                Executor(
+                    interactor: r.resolve(CommitInteractor.self),
+                    console: r.resolve(Console.self)
+                )
+            }
+        }
+    }
+}

--- a/Sources/CurieCore/Assembly/CoreAssembly.swift
+++ b/Sources/CurieCore/Assembly/CoreAssembly.swift
@@ -75,6 +75,13 @@ public final class CoreAssembly: Assembly {
                 console: r.resolve(Console.self)
             )
         }
+        registry.register(CommitInteractor.self) { r in
+            DefaultCommitInteractor(
+                configurator: r.resolve(VMConfigurator.self),
+                imageCache: r.resolve(ImageCache.self),
+                console: r.resolve(Console.self)
+            )
+        }
     }
 
     private func assembleUtils(_ registry: Registry) {

--- a/Sources/CurieCore/Interactors/CommitInteractor.swift
+++ b/Sources/CurieCore/Interactors/CommitInteractor.swift
@@ -1,0 +1,65 @@
+import Combine
+import CurieCommon
+import Foundation
+
+public struct CommitInteractorContext {
+    public var containerReference: String
+    public var imageReference: String?
+
+    public init(containerReference: String, imageReference: String?) {
+        self.containerReference = containerReference
+        self.imageReference = imageReference
+    }
+}
+
+public protocol CommitInteractor {
+    func execute(with context: CommitInteractorContext) throws
+}
+
+public final class DefaultCommitInteractor: CommitInteractor {
+    private let configurator: VMConfigurator
+    private let imageCache: ImageCache
+    private let console: Console
+
+    private var cancellables = Set<AnyCancellable>()
+
+    init(
+        configurator: VMConfigurator,
+        imageCache: ImageCache,
+        console: Console
+    ) {
+        self.configurator = configurator
+        self.imageCache = imageCache
+        self.console = console
+    }
+
+    public func execute(with context: CommitInteractorContext) throws {
+        let sourceReference = try imageCache.findContainerReference(context.containerReference)
+        let targetReference = try context.imageReference.map { try ImageReference(
+            id: sourceReference.id,
+            descriptor: .init(reference: $0),
+            type: .image
+        ) } ?? sourceReference.asImageReference()
+
+        let bundle = VMBundle(path: imageCache.path(to: targetReference))
+        let vm = try configurator.loadVM(with: bundle)
+
+        guard vm.virtualMachine.state == .stopped || vm.virtualMachine.state == .paused else {
+            throw CoreError.generic("Cammit failed, container is not stopped or paused")
+        }
+
+        try imageCache.moveImage(source: sourceReference, target: targetReference)
+
+        console.text("Image \(targetReference.id.description) has been saved")
+    }
+}
+
+private extension ImageReference {
+    func asImageReference() -> ImageReference {
+        ImageReference(
+            id: id,
+            descriptor: .init(repository: String(descriptor.repository.dropFirst(14)), tag: descriptor.tag),
+            type: .image
+        )
+    }
+}

--- a/Sources/CurieCore/Interactors/CreateInteractor.swift
+++ b/Sources/CurieCore/Interactors/CreateInteractor.swift
@@ -1,8 +1,6 @@
 import Combine
 import CurieCommon
 import Foundation
-import TSCBasic
-import Virtualization
 
 public struct CreateInteractorContext {
     public var reference: String


### PR DESCRIPTION
Allows to save container as image.

Test Plan:
- Ensure all CI checks pass 
- Create container, start and stop it, call `curie commit <reference>`, verify the container has been converted into image