### PR TITLE
Revert "Skip @id repository prefix for containers (#36)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ curie ps
 # Example output
 
 CONTAINER ID     REPOSITORY                               TAG     CREATED           SIZE
-7984867efb71     myteam/myimage/ci/test     2.1     3 minutes ago     60.03 GB
+7984867efb71     @7984867efb71/myteam/myimage/ci/test     2.1     3 minutes ago     60.03 GB
 ```
 
 The command has also `--format` (`-f`) parameter which allows to output JSON.
@@ -121,17 +121,13 @@ The command has also `--format` (`-f`) parameter which allows to output JSON.
 All changes that are made in the container will be applied to the image once the container is closed.
 
 ```sh
-curie start myteam/myimage/ci/test
+curie start @7984867efb71/myteam/myimage/ci/test
 ```
 
 #### Inspect an image or a container
 
 ```sh
 curie inspect myteam/myimage/ci/test:2.3
-
-# or
-
-curie inspect 904183fe6271 # Using [<IMAGE ID> | <CONTAINER ID>]
 
 # Example output
 

--- a/Sources/CurieCore/Cache/ImageCache.swift
+++ b/Sources/CurieCore/Cache/ImageCache.swift
@@ -268,13 +268,13 @@ private extension ImageDescriptor {
 }
 
 private extension Target {
-    func imageDescriptor(source: ImageReference, imageId _: ImageID) throws -> ImageDescriptor {
+    func imageDescriptor(source: ImageReference, imageId: ImageID) throws -> ImageDescriptor {
         switch self {
         case let .reference(reference):
             return try ImageDescriptor(reference: reference)
         case .ephemeral:
             return ImageDescriptor(
-                repository: source.descriptor.repository,
+                repository: "@\(imageId.description)/\(source.descriptor.repository)",
                 tag: source.descriptor.tag
             )
         }

--- a/Sources/CurieCore/Interactors/CommitInteractor.swift
+++ b/Sources/CurieCore/Interactors/CommitInteractor.swift
@@ -58,7 +58,7 @@ private extension ImageReference {
     func asImageReference() -> ImageReference {
         ImageReference(
             id: id,
-            descriptor: .init(repository: descriptor.repository, tag: descriptor.tag),
+            descriptor: .init(repository: String(descriptor.repository.dropFirst(14)), tag: descriptor.tag),
             type: .image
         )
     }


### PR DESCRIPTION
This reverts commit 78f93b730dcc7f7aa189bc2d3dd225570ba5788d.

Skipping id would mean we cannot create 2 containers from the same image.