### PR TITLE
Allow to create a container with a name

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,9 @@ curie inspect myteam/myimage/ci/test:2.3
 
 # Example output
 
-State:
+Metadata:
   id: 9bf95fe0f7f0
+  name: <none>
   createdAt: 2023-09-17T18:22:58Z
   network:
     devices:

--- a/Sources/CurieCommand/Commands/CreateCommand.swift
+++ b/Sources/CurieCommand/Commands/CreateCommand.swift
@@ -13,6 +13,13 @@ struct CreateCommand: Command {
     @Argument(help: "Reference \(CurieCore.Constants.referenceFormat).")
     var reference: String
 
+    @Option(
+        name: .shortAndLong,
+        help: "Assign a name to the container.",
+        completion: .default
+    )
+    var name: String?
+
     final class Executor: CommandExecutor {
         private let interactor: CreateInteractor
         private let console: Console
@@ -24,7 +31,8 @@ struct CreateCommand: Command {
 
         func execute(command: CreateCommand) throws {
             try interactor.execute(with: .init(
-                reference: command.reference
+                reference: command.reference,
+                name: command.name
             ))
         }
     }

--- a/Sources/CurieCore/Assembly/CoreAssembly.swift
+++ b/Sources/CurieCore/Assembly/CoreAssembly.swift
@@ -78,6 +78,7 @@ public final class CoreAssembly: Assembly {
         registry.register(CreateInteractor.self) { r in
             DefaultCreateInteractor(
                 imageCache: r.resolve(ImageCache.self),
+                bundleParser: r.resolve(VMBundleParser.self),
                 console: r.resolve(Console.self)
             )
         }

--- a/Sources/CurieCore/Config/Constrants.swift
+++ b/Sources/CurieCore/Config/Constrants.swift
@@ -7,7 +7,6 @@ public enum Constants {
     public static let referenceFormat = "<repository>[:<tag>]"
 
     static let defaultConfig = VMConfig(
-        name: "Anonymous VM",
         cpuCount: 4,
         memorySize: .init(bytes: 4 * 1024 * 1024 * 1024),
         display: .init(width: 1920, height: 1080, pixelsPerInch: 80),

--- a/Sources/CurieCore/Interactors/CreateInteractor.swift
+++ b/Sources/CurieCore/Interactors/CreateInteractor.swift
@@ -4,11 +4,14 @@ import Foundation
 
 public struct CreateInteractorContext {
     public var reference: String
+    public var name: String?
 
     public init(
-        reference: String
+        reference: String,
+        name: String?
     ) {
         self.reference = reference
+        self.name = name
     }
 }
 
@@ -18,21 +21,29 @@ public protocol CreateInteractor {
 
 public final class DefaultCreateInteractor: CreateInteractor {
     private let imageCache: ImageCache
+    private let bundleParser: VMBundleParser
     private let console: Console
 
     private var cancellables = Set<AnyCancellable>()
 
     init(
         imageCache: ImageCache,
+        bundleParser: VMBundleParser,
         console: Console
     ) {
         self.imageCache = imageCache
+        self.bundleParser = bundleParser
         self.console = console
     }
 
     public func execute(with context: CreateInteractorContext) throws {
         let sourceReference = try imageCache.findImageReference(context.reference)
-        let targetReference = try imageCache.cloneImage(source: sourceReference, target: .ephemeral)
+        let targetReference = try imageCache.cloneImage(source: sourceReference, target: .newReference)
+
+        let bundle = VMBundle(path: imageCache.path(to: targetReference))
+        try bundleParser.updateMetadata(bundle: bundle) { metadata in
+            metadata.name = context.name
+        }
 
         console.text(targetReference.id.description)
     }

--- a/Sources/CurieCore/Interactors/InspectInteractor.swift
+++ b/Sources/CurieCore/Interactors/InspectInteractor.swift
@@ -48,7 +48,7 @@ final class DefaultInspectInteractor: InspectInteractor {
         let bundle = VMBundle(path: imageCache.path(to: reference))
         let info = try bundleParser.readInfo(from: bundle)
         let arpItems = try aprClient.executeARPQuery()
-        let macAddresses = Set(info.state.network.flatMap { $0.devices.map(\.value.MACAddress) } ?? [])
+        let macAddresses = Set(info.metadata.network.flatMap { $0.devices.map(\.value.MACAddress) } ?? [])
         let filteredArpaRows = arpItems.filter { macAddresses.contains($0.macAddress) }
 
         let item = Item(info: info, arp: filteredArpaRows)

--- a/Sources/CurieCore/Interactors/PsInteractor.swift
+++ b/Sources/CurieCore/Interactors/PsInteractor.swift
@@ -47,6 +47,7 @@ final class DefaultPsInteractor: PsInteractor {
                 "tag",
                 "created",
                 "size",
+                "name",
             ],
             values: images.map { [
                 $0.reference.id.description,
@@ -54,6 +55,7 @@ final class DefaultPsInteractor: PsInteractor {
                 $0.reference.descriptor.tag ?? "<none>",
                 dateFormatter.localizedString(for: $0.createAt, relativeTo: wallClock.now()),
                 $0.size.description,
+                $0.name ?? "<none>",
             ] }
         )
         let config = TableRenderer.Config(format: context.format.rendererFormat())

--- a/Sources/CurieCore/Interactors/RunInteractor.swift
+++ b/Sources/CurieCore/Interactors/RunInteractor.swift
@@ -48,7 +48,7 @@ public final class DefaultRunInteractor: RunInteractor {
         console.text("Run image \(context.reference)")
 
         let sourceReference = try imageCache.findImageReference(context.reference)
-        let targetReference = try imageCache.cloneImage(source: sourceReference, target: .ephemeral)
+        let targetReference = try imageCache.cloneImage(source: sourceReference, target: .newReference)
 
         let bundle = VMBundle(path: imageCache.path(to: targetReference))
         let vm = try configurator.loadVM(with: bundle)

--- a/Sources/CurieCore/MacOSWindowApp/MacOSWindowAppLauncher.swift
+++ b/Sources/CurieCore/MacOSWindowApp/MacOSWindowAppLauncher.swift
@@ -22,7 +22,7 @@ private struct MacOSWindowApp: App {
     private var appDelegate: MacOSWindowAppDelegate
 
     var body: some Scene {
-        WindowGroup(MacOSWindowApp.vm.config.name) {
+        WindowGroup(MacOSWindowApp.vm.metadata.name ?? MacOSWindowApp.vm.metadata.id.description) {
             Group {
                 MacOSWindowAppViewView(vm: MacOSWindowApp.vm).onAppear {
                     NSWindow.allowsAutomaticWindowTabbing = false

--- a/Sources/CurieCore/VM/ImageRunner.swift
+++ b/Sources/CurieCore/VM/ImageRunner.swift
@@ -34,7 +34,7 @@ final class DefaultImageRunner: ImageRunner {
         vm.start(completionHandler: { [console] result in
             switch result {
             case .success:
-                console.text("Container \(info.state.id.description) started")
+                console.text("Container \(info.metadata.id.description) started")
             case let .failure(error):
                 console.error("Failed to start container. \(error)")
             }

--- a/Sources/CurieCore/VM/VM.swift
+++ b/Sources/CurieCore/VM/VM.swift
@@ -14,6 +14,7 @@ final class VM: NSObject {
     }
 
     let config: VMConfig
+    let metadata: VMMetadata
 
     private let vm: VZVirtualMachine
     private let console: Console
@@ -24,10 +25,12 @@ final class VM: NSObject {
     init(
         vm: VZVirtualMachine,
         config: VMConfig,
+        metadata: VMMetadata,
         console: Console
     ) {
         self.vm = vm
         self.config = config
+        self.metadata = metadata
         self.console = console
 
         super.init()

--- a/Sources/CurieCore/VM/VMBundle.swift
+++ b/Sources/CurieCore/VM/VMBundle.swift
@@ -35,8 +35,12 @@ public struct VMBundle {
         path("config.json")
     }
 
-    public var state: AbsolutePath {
-        path("state.json")
+    public var metadata: AbsolutePath {
+        path("metadata.json")
+    }
+
+    public var container: AbsolutePath {
+        path("container.json")
     }
 
     // MARK: - Private

--- a/Sources/CurieCore/VM/VMConfig.swift
+++ b/Sources/CurieCore/VM/VMConfig.swift
@@ -120,7 +120,6 @@ public struct VMConfig: Equatable, Codable {
         var devices: [Device]
     }
 
-    var name: String
     var cpuCount: Int
     var memorySize: MemorySize
     var display: DisplayConfig
@@ -131,7 +130,6 @@ extension VMConfig: CustomStringConvertible {
     public var description: String {
         """
         Config:
-          name: \(name)
           cpuCount: \(cpuCount)
           memorySize: \(memorySize)
           display:

--- a/Sources/CurieCore/VM/VMInfo.swift
+++ b/Sources/CurieCore/VM/VMInfo.swift
@@ -2,14 +2,14 @@ import Foundation
 
 struct VMInfo: Codable {
     let config: VMConfig
-    let state: VMState
+    let metadata: VMMetadata
 }
 
 extension VMInfo: CustomStringConvertible {
     var description: String {
         """
 
-        \(state.description)
+        \(metadata.description)
 
         \(config.description)
 

--- a/Sources/CurieCore/VM/VMMetadata.swift
+++ b/Sources/CurieCore/VM/VMMetadata.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct VMState: Equatable, Codable {
+struct VMMetadata: Equatable, Codable {
     struct NetworkDevice: Equatable, Codable {
         let MACAddress: String
     }
@@ -10,15 +10,17 @@ struct VMState: Equatable, Codable {
     }
 
     var id: ImageID
+    var name: String?
     var createdAt: Date
     var network: Network?
 }
 
-extension VMState: CustomStringConvertible {
+extension VMMetadata: CustomStringConvertible {
     public var description: String {
         """
-        State:
+        Metadata:
           id: \(id.description)
+          name: \(name ?? "<none>")
           createdAt: \(dateFormatter.string(from: createdAt))
           network:
             devices:
@@ -31,7 +33,7 @@ extension VMState: CustomStringConvertible {
     }
 }
 
-extension [Int: VMState.NetworkDevice] {
+extension [Int: VMMetadata.NetworkDevice] {
     var description: String {
         let prefix = "      "
         return sorted { $0.key < $1.key }.map { index, value in

--- a/Sources/CurieCoreTests/VM/VMBundleParserTests.swift
+++ b/Sources/CurieCoreTests/VM/VMBundleParserTests.swift
@@ -37,7 +37,6 @@ final class DefaultVMBundleParserTests: XCTestCase {
                 "pixelsPerInch" : 100,
                 "height" : 480
               },
-              "name" : "Test",
               "memorySize" : {
                 "bytes" : 1073741824
               }
@@ -50,7 +49,6 @@ final class DefaultVMBundleParserTests: XCTestCase {
 
         // Then
         XCTAssertEqual(config, .init(
-            name: "test",
             cpuCount: 8,
             memorySize: .init(bytes: 1024 * 1024 * 1024),
             display: .init(width: 640, height: 480, pixelsPerInch: 100),


### PR DESCRIPTION
- Renamed `state.json` to `metadata.json` to better reflect the content of the file
- Existing images will need to be manually modified (migration is not implemented)

Test Plan:
- Ensure all CI checks pass
- Verify `curie create <reference> --name "my-testname"` creates new container with the specified name