### PR TITLE
Ensure `download` command accepts relative paths

### DIFF
--- a/Sources/CurieCore/Interactors/DownloadInteractor.swift
+++ b/Sources/CurieCore/Interactors/DownloadInteractor.swift
@@ -34,7 +34,7 @@ public final class DefaultDownloadInteractor: DownloadInteractor {
     }
 
     public func execute(with context: DownloadInteractorContext) throws {
-        guard let path = try? AbsolutePath(validating: context.path) else {
+        guard let path = try? fileSystem.absolutePath(from: context.path) else {
             throw CoreError.generic("Invalid path \"\(context.path)\"")
         }
         guard !fileSystem.exists(at: path) else {


### PR DESCRIPTION
Current version only accepts absolute paths.

Test Plan:
- Ensure all CI checks pass
- Verify `curie download -p restore-file.ipsw` works