### PR TITLE
Use abs path to arp

### DIFF
--- a/Sources/CurieCore/Utils/ARPClient.swift
+++ b/Sources/CurieCore/Utils/ARPClient.swift
@@ -19,7 +19,7 @@ final class DefaultARPClient: ARPClient {
 
     func executeARPQuery() throws -> [ARPItem] {
         let captureOutput = CaptureOutput()
-        try system.execute(["arp", "-an"], output: .custom(captureOutput))
+        try system.execute(["/usr/sbin/arp", "-an"], output: .custom(captureOutput))
 
         let tokens = captureOutput.outputString
             .split(separator: "\n")


### PR DESCRIPTION
Workaround for:

```
amfDaemon: (AppKit) NSURLIsPackageKey lookup returned Error Domain=NSCocoaErrorDomain Code=260 "The file "arp" couldn't be opened because there is no such file." UserInfo={NSURL=file:///Library/Frameworks/Python.framework/Versions/3.10/bin/arp/, NSFilePath=/Library/Frameworks/Python.framework/Versions/3.10/bin/arp, NSUnderlyingError=0x600001c5fc90 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}} for path /Library/Frameworks/Python.framework/Versions/3.10/bin/arp.
2024-02-23 17:50:07.179962+0000 0x1a8c     Default     0x0                  825    0    JamfDaemon: (AppKit) NSURLIsPackageKey lookup returned Error Domain=NSCocoaErrorDomain Code=260 "The file "arp" couldn't be opened because there is no such file." UserInfo={NSURL=file:///Library/Frameworks/Python.framework/Versions/3.11/bin/arp/, NSFilePath=/Library/Frameworks/Python.framework/Versions/3.11/bin/arp, NSUnderlyingError=0x600001c699b0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}} for path /Library/Frameworks/Python.framework/Versions/3.11/bin/arp.
```

Test Plan:
- Ensure all CI checks pass