### PR TITLE
Switch to M1 runner

### DIFF
--- a/.github/workflows/curie.yml
+++ b/.github/workflows/curie.yml
@@ -38,3 +38,17 @@ jobs:
           ${{ runner.os }}-spm-
     - name: build
       run: make build
+
+  test:
+    name: Test
+    runs-on: macos-14
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: .build
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-spm-
+    - name: test
+      run: make test


### PR DESCRIPTION
- It appears M1 runners are now supported for free tire: https://github.com/actions/runner-images/issues/9254.
- Switched to `macos-14`
- Enable build on CI
- Enable test on CI

Test Plan:
- Ensure all CI checks pass