### PR TITLE
Leverage automaticallyReconfiguresDisplay

### DIFF
--- a/Sources/CurieCore/MacOSWindowApp/MacOSWindowAppLauncher.swift
+++ b/Sources/CurieCore/MacOSWindowApp/MacOSWindowAppLauncher.swift
@@ -68,6 +68,9 @@ private struct MacOSWindowAppViewView: NSViewRepresentable {
     func makeNSView(context _: Context) -> NSViewType {
         let machineView = VZVirtualMachineView()
         machineView.capturesSystemKeys = false
+        if #available(macOS 14.0, *) {
+            machineView.automaticallyReconfiguresDisplay = true
+        }
         return machineView
     }
 


### PR DESCRIPTION
- `automaticallyReconfiguresDisplay` indicates whether the graphics display associated with this view automatically reconfigures with respect to view changes.
- requires macOS 14.0+

Reference:
> Set this property to [true](https://developer.apple.com/documentation/swift/true) to automatically resize or reconfigure this graphics display when the view properties update. For example, resizing the display when the view has a live resize operation. When enabled, the graphics display automatically reconfigures to match the host display environment.
You can set this property on only a single [VZVirtualMachineView](https://developer.apple.com/documentation/virtualization/vzvirtualmachineview) targeting a particular [VZGraphicsDisplay](https://developer.apple.com/documentation/virtualization/vzgraphicsdisplay) at a time. If multiple VZVirtualMachineView views targeting the same VZGraphicsDisplay enable this property, only one view respects the property, and the framework disables the property on the other views.
The default is [false](https://developer.apple.com/documentation/swift/false).

Source: https://developer.apple.com/documentation/virtualization/vzvirtualmachineview/4168520-automaticallyreconfiguresdisplay.

Test Plan:
- Ensure all CI checks pass
- Launch the app with window mode, verify the content is rendered correctly after the window is resized