### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/Sources/CurieCommand/Constants.swift
+++ b/Sources/CurieCommand/Constants.swift
@@ -8,7 +8,7 @@ final class Constants {
             debugVersionIdentifier(),
             gitHashVersionIdentifier(),
         ].compactMap { $0 }
-        return Version(0, 1, 0, buildMetadataIdentifiers: identifiers)
+        return Version(0, 2, 0, buildMetadataIdentifiers: identifiers)
     }()
 
     private static let gitHash = "#GIT_SHORT_HASH#"


### PR DESCRIPTION
Test Plan:
- Ensure all CI checks pass
- Build locally (`make build; make sign`) and verify `curie version` shows `0.2.0...`