### PR TITLE
Add `make help` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,26 @@
 mise := ~/.local/bin/mise
 
+define HELP_BODY
+USAGE: make <subcommand>
+
+SUBCOMMANDS:
+  help                    Show help.
+  setup                   Set up development environment.
+  clean                   Clean build folder.
+  env                     Show build environment.
+  build                   Build.
+  test                    Run tests.
+  sign                    Sign executable.
+  format                  Format source code.
+  autocorrect             Autocorrect lint issues if possible.
+  lint                    Lint source code.
+
+endef
+export HELP_BODY
+
+help:
+	@echo "$$HELP_BODY"
+
 setup:
 	curl "https://mise.run" | sh
 


### PR DESCRIPTION
Added help command to improve visibility of all commands used during development.

```sh
➜ make help
USAGE: make <subcommand>

SUBCOMMANDS:
  help                    Show help.
  setup                   Set up development environment.
  clean                   Clean build folder.
  env                     Show build environment.
  build                   Build.
  test                    Run tests.
  sign                    Sign executable.
  format                  Format source code.
  autocorrect             Autocorrect lint issues if possible.
  lint                    Lint source code.

```

Test Plan:
- Ensure all CI checks pass