### PR TITLE
Refactor `DownloadInteractor`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,10 +39,18 @@ let package = Package(
                 .product(name: "SCInject", package: "SwiftCommons"),
             ]
         ),
+        .target(
+            name: "CurieCoreMocks",
+            dependencies: [
+                .target(name: "CurieCore"),
+                .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+            ]
+        ),
         .testTarget(
             name: "CurieCoreTests",
             dependencies: [
                 .target(name: "CurieCore"),
+                .target(name: "CurieCoreMocks"),
                 .target(name: "CurieCommonMocks"),
                 .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
                 .product(name: "SCInject", package: "SwiftCommons"),

--- a/Sources/CurieCommon/Assembly/CommonAssembly.swift
+++ b/Sources/CurieCommon/Assembly/CommonAssembly.swift
@@ -11,14 +11,20 @@ public final class CommonAssembly: Assembly {
         registry.register(Console.self) { r in
             DefaultConsole(output: r.resolve(Output.self))
         }
+        registry.register(WallClock.self) { _ in
+            DefaultWallClock()
+        }
         registry.register(FileSystem.self) { _ in
             DefaultFileSystem()
         }
         registry.register(System.self) { _ in
             DefaultSystem()
         }
-        registry.register(ProcessRunloop.self, .container) { _ in
-            DefaultProcessRunloop()
+        registry.register(RunLoop.self, .container) { _ in
+            DefaultRunLoop()
+        }
+        registry.register(HTTPClient.self) { _ in
+            URLSessionHTTPClient()
         }
     }
 }

--- a/Sources/CurieCommon/HTTPClient.swift
+++ b/Sources/CurieCommon/HTTPClient.swift
@@ -1,0 +1,55 @@
+import Foundation
+import TSCBasic
+
+public struct HTTPClientDownloadProgress {
+    public let received: MemorySize
+    public let expected: MemorySize
+    public let progress: Double
+
+    public init(received: MemorySize, expected: MemorySize, progress: Double) {
+        self.received = received
+        self.expected = expected
+        self.progress = progress
+    }
+}
+
+public protocol HTTPClientDownloadTracker: AnyObject {
+    func httpClient(_ httpClient: HTTPClient, progress: HTTPClientDownloadProgress)
+}
+
+public protocol HTTPClient {
+    func download(url: URL, tracker: (any HTTPClientDownloadTracker)?) async throws -> (URL, URLResponse)
+}
+
+public final class URLSessionHTTPClient: HTTPClient {
+    private let urlSession = URLSession.shared
+
+    public func download(url: URL, tracker: (any HTTPClientDownloadTracker)?) async throws -> (URL, URLResponse) {
+        var observer: NSKeyValueObservation?
+        let result: (url: URL, _: URLResponse) = try await withCheckedThrowingContinuation { [self] continuation in
+            let task = urlSession.downloadTask(with: url) { url, response, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let url, let response {
+                    continuation.resume(returning: (url, response))
+                } else {
+                    continuation.resume(throwing: CoreError.generic("Unexpected result"))
+                }
+            }
+            if let tracker {
+                observer = task.progress.observe(\.fractionCompleted, options: [.initial, .new]) { _, _ in
+                    let received = MemorySize(bytes: UInt64(task.countOfBytesReceived))
+                    let expected = MemorySize(bytes: UInt64(task.countOfBytesExpectedToReceive))
+                    let progress = expected.bytes > 0 ? Double(received.bytes) / Double(expected.bytes) : 0.0
+                    tracker.httpClient(
+                        self,
+                        progress: .init(received: received, expected: expected, progress: progress)
+                    )
+                }
+            }
+            task.resume()
+        }
+        withExtendedLifetime(observer) {}
+        return result
+    }
+}

--- a/Sources/CurieCommon/System.swift
+++ b/Sources/CurieCommon/System.swift
@@ -88,7 +88,7 @@ final class DefaultSystem: System {
         let sigterm = makeSIGTERMSourceSignal(signalHandler: signalHandler)
         withExtendedLifetime([sigint, sigterm]) {
             while !cancellable.isCancelled() {
-                RunLoop.main.run(until: .now + 1)
+                Foundation.RunLoop.main.run(until: .now + 1)
             }
         }
     }

--- a/Sources/CurieCommonMocks/MockConsole.swift
+++ b/Sources/CurieCommonMocks/MockConsole.swift
@@ -1,0 +1,65 @@
+import CurieCommon
+import Foundation
+
+public final class MockOutput: Output {
+    public enum Call: Equatable {
+        case write(string: String, stream: CurieCommon.OutputStream)
+    }
+
+    public private(set) var calls: [Call] = []
+
+    public func write(_ string: String, to stream: CurieCommon.OutputStream) {
+        calls.append(.write(string: string, stream: stream))
+    }
+
+    public var redirected: Bool = false
+}
+
+public final class MockConsole: Console {
+    public enum Call: Equatable {
+        // swiftlint:disable:next duplicate_enum_cases
+        case text(String)
+
+        // swiftlint:disable:next duplicate_enum_cases
+        case text(String, Bool)
+        case error(String)
+        case clear
+
+        // swiftlint:disable:next duplicate_enum_cases
+        case progress(String, Double)
+
+        // swiftlint:disable:next duplicate_enum_cases
+        case progress(String, Double, String?)
+    }
+
+    public private(set) var calls: [Call] = []
+
+    public var output: any CurieCommon.Output = MockOutput()
+    public var quiet: Bool = false
+
+    public init() {}
+
+    public func text(_ message: String) {
+        calls.append(.text(message))
+    }
+
+    public func text(_ message: String, always: Bool) {
+        calls.append(.text(message, always))
+    }
+
+    public func error(_ message: String) {
+        calls.append(.error(message))
+    }
+
+    public func clear() {
+        calls.append(.clear)
+    }
+
+    public func progress(prompt: String, progress: Double) {
+        calls.append(.progress(prompt, progress))
+    }
+
+    public func progress(prompt: String, progress: Double, suffix: String?) {
+        calls.append(.progress(prompt, progress, suffix))
+    }
+}

--- a/Sources/CurieCommonMocks/MockHTTPClient.swift
+++ b/Sources/CurieCommonMocks/MockHTTPClient.swift
@@ -1,0 +1,32 @@
+import CurieCommon
+import Foundation
+
+public final class MockHTTPClient: HTTPClient {
+    public struct MockDownload {
+        public var url: URL
+        public let response: URLResponse
+        public var progress: [HTTPClientDownloadProgress]
+
+        public init(url: URL, response: URLResponse, progress: [HTTPClientDownloadProgress]) {
+            self.url = url
+            self.response = response
+            self.progress = progress
+        }
+    }
+
+    public var mockDownloadResult: [URL: [MockDownload]] = [:]
+
+    public init() {}
+
+    public func download(url: URL, tracker: (any HTTPClientDownloadTracker)?) async throws -> (URL, URLResponse) {
+        guard let download = mockDownloadResult[url]?.popLast() else {
+            fatalError("Missing mock download")
+        }
+
+        for item in download.progress {
+            tracker?.httpClient(self, progress: item)
+        }
+
+        return (download.url, download.response)
+    }
+}

--- a/Sources/CurieCore/Assembly/CoreAssembly.swift
+++ b/Sources/CurieCore/Assembly/CoreAssembly.swift
@@ -39,7 +39,7 @@ public final class CoreAssembly: Assembly {
                 installer: r.resolve(VMInstaller.self),
                 imageCache: r.resolve(ImageCache.self),
                 fileSystem: r.resolve(FileSystem.self),
-                runloop: r.resolve(ProcessRunloop.self),
+                runLoop: r.resolve(RunLoop.self),
                 console: r.resolve(Console.self)
             )
         }
@@ -101,7 +101,7 @@ public final class CoreAssembly: Assembly {
             DefaultDownloadInteractor(
                 downloader: r.resolve(RestoreImageDownloader.self),
                 fileSystem: r.resolve(FileSystem.self),
-                system: r.resolve(System.self),
+                runLoop: r.resolve(RunLoop.self),
                 console: r.resolve(Console.self)
             )
         }
@@ -145,6 +145,8 @@ public final class CoreAssembly: Assembly {
         }
         registry.register(RestoreImageDownloader.self) { r in
             DefaultRestoreImageDownloader(
+                restoreImageService: r.resolve(RestoreImageService.self),
+                httpClient: r.resolve(HTTPClient.self),
                 fileSystem: r.resolve(FileSystem.self),
                 console: r.resolve(Console.self)
             )
@@ -172,13 +174,13 @@ public final class CoreAssembly: Assembly {
                 console: r.resolve(Console.self)
             )
         }
-        registry.register(WallClock.self) { _ in
-            DefaultWallClock()
-        }
         registry.register(ARPClient.self) { r in
             DefaultARPClient(
                 system: r.resolve(System.self)
             )
+        }
+        registry.register(RestoreImageService.self) { _ in
+            DefaultRestoreImageService()
         }
     }
 }

--- a/Sources/CurieCore/Interactors/BuildInteractor.swift
+++ b/Sources/CurieCore/Interactors/BuildInteractor.swift
@@ -31,7 +31,7 @@ final class DefaultBuildInteractor: BuildInteractor {
     private let installer: VMInstaller
     private let imageCache: ImageCache
     private let fileSystem: CurieCommon.FileSystem
-    private let runloop: ProcessRunloop
+    private let runLoop: CurieCommon.RunLoop
     private let console: Console
 
     init(
@@ -40,7 +40,7 @@ final class DefaultBuildInteractor: BuildInteractor {
         installer: VMInstaller,
         imageCache: ImageCache,
         fileSystem: CurieCommon.FileSystem,
-        runloop: ProcessRunloop,
+        runLoop: CurieCommon.RunLoop,
         console: Console
     ) {
         self.downloader = downloader
@@ -48,7 +48,7 @@ final class DefaultBuildInteractor: BuildInteractor {
         self.installer = installer
         self.imageCache = imageCache
         self.fileSystem = fileSystem
-        self.runloop = runloop
+        self.runLoop = runLoop
         self.console = console
     }
 
@@ -73,7 +73,7 @@ final class DefaultBuildInteractor: BuildInteractor {
         context: BuildInteractorContext,
         restoreImagePath: String
     ) throws {
-        try runloop.run { [self] _ in
+        try runLoop.run { [self] _ in
             // Get restore image path
             let restoreImagePath = try prepareRestoreImagePath(path: restoreImagePath)
 

--- a/Sources/CurieCore/Interactors/DownloadInteractor.swift
+++ b/Sources/CurieCore/Interactors/DownloadInteractor.swift
@@ -18,18 +18,18 @@ public protocol DownloadInteractor {
 public final class DefaultDownloadInteractor: DownloadInteractor {
     private let downloader: RestoreImageDownloader
     private let fileSystem: CurieCommon.FileSystem
-    private let system: System
+    private let runLoop: CurieCommon.RunLoop
     private let console: Console
 
     init(
         downloader: RestoreImageDownloader,
         fileSystem: CurieCommon.FileSystem,
-        system: System,
+        runLoop: CurieCommon.RunLoop,
         console: Console
     ) {
         self.downloader = downloader
         self.fileSystem = fileSystem
-        self.system = system
+        self.runLoop = runLoop
         self.console = console
     }
 
@@ -41,11 +41,8 @@ public final class DefaultDownloadInteractor: DownloadInteractor {
             throw CoreError.generic("File already exists at path \"\(context.path)\"")
         }
 
-        downloader.download(to: path, completion: exit)
-
-        system.keepAlive { [console] exit in
-            console.text("Download has been cancelled")
-            exit(0)
+        try runLoop.run { [self] _ in
+            try await downloader.download(to: path)
         }
     }
 }

--- a/Sources/CurieCore/Utils/RestoreImageService.swift
+++ b/Sources/CurieCore/Utils/RestoreImageService.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Virtualization
+
+public struct RestoreImage: Equatable {
+    var url: URL
+    var isSupported: Bool
+    var buildVersion: String
+    var operatingSystemVersion: String
+
+    public init(url: URL, isSupported: Bool, buildVersion: String, operatingSystemVersion: String) {
+        self.url = url
+        self.isSupported = isSupported
+        self.buildVersion = buildVersion
+        self.operatingSystemVersion = operatingSystemVersion
+    }
+}
+
+public protocol RestoreImageService {
+    func latestSupported() async throws -> RestoreImage
+}
+
+final class DefaultRestoreImageService: RestoreImageService {
+    func latestSupported() async throws -> RestoreImage {
+        try await withCheckedThrowingContinuation { continuation in
+            VZMacOSRestoreImage.fetchLatestSupported { result in
+                switch result {
+                case let .success(restoreImage):
+                    continuation.resume(returning: .init(
+                        url: restoreImage.url,
+                        isSupported: restoreImage.isSupported,
+                        buildVersion: restoreImage.buildVersion,
+                        operatingSystemVersion: restoreImage.operatingSystemVersion.description
+                    ))
+                case let .failure(error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+
+private extension OperatingSystemVersion {
+    var description: String {
+        "\(majorVersion).\(minorVersion).\(patchVersion)"
+    }
+}

--- a/Sources/CurieCoreMocks/Utils/MockRestoreImageService.swift
+++ b/Sources/CurieCoreMocks/Utils/MockRestoreImageService.swift
@@ -1,0 +1,16 @@
+import CurieCore
+import Foundation
+import Virtualization
+
+public final class MockRestoreImageService: RestoreImageService {
+    public var mockLatestSupported: [CurieCore.RestoreImage] = []
+
+    public init() {}
+
+    public func latestSupported() async throws -> CurieCore.RestoreImage {
+        guard let latestSupported = mockLatestSupported.popLast() else {
+            fatalError("Missing mock latest supported")
+        }
+        return latestSupported
+    }
+}

--- a/Sources/CurieCoreTests/Interactors/DownloadInteractorTests.swift
+++ b/Sources/CurieCoreTests/Interactors/DownloadInteractorTests.swift
@@ -1,0 +1,112 @@
+import CurieCommon
+import CurieCommonMocks
+import CurieCoreMocks
+import Foundation
+import XCTest
+
+@testable import CurieCore
+
+final class DownloadInteractorTests: XCTestCase {
+    private var subject: DefaultDownloadInteractor!
+    private var downloader: DefaultRestoreImageDownloader!
+    private var fileSystem: DefaultFileSystem!
+    private var runLoop: DefaultRunLoop!
+    private var restoreImageService: MockRestoreImageService!
+    private var httpClient: MockHTTPClient!
+    private var console: MockConsole!
+    private var directory: Directory!
+
+    private let fileManager = FileManager.default
+
+    override func setUpWithError() throws {
+        super.setUp()
+        httpClient = MockHTTPClient()
+        console = MockConsole()
+        restoreImageService = MockRestoreImageService()
+        fileSystem = DefaultFileSystem()
+        downloader = DefaultRestoreImageDownloader(
+            restoreImageService: restoreImageService,
+            httpClient: httpClient,
+            fileSystem: fileSystem,
+            console: console
+        )
+        runLoop = DefaultRunLoop(interval: .short)
+        subject = DefaultDownloadInteractor(
+            downloader: downloader,
+            fileSystem: fileSystem,
+            runLoop: runLoop,
+            console: console
+        )
+
+        try directory = fileSystem.makeTemporaryDirectory()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        httpClient = nil
+        console = nil
+        restoreImageService = nil
+        fileSystem = nil
+        downloader = nil
+        runLoop = nil
+        subject = nil
+
+        directory = nil
+    }
+
+    func testExecute_validContext() throws {
+        // Given
+        let destination = directory.path.appending(component: "destination.ipsw")
+        let context = DownloadInteractorContext(path: destination.pathString)
+        restoreImageService.mockLatestSupported = [anyRestoreImage]
+        httpClient.mockDownloadResult[anySourceURL] = try [anyDownload()]
+
+        // When
+        try subject.execute(with: context)
+
+        // Then
+        XCTAssertTrue(fileManager.fileExists(atPath: destination.pathString))
+        XCTAssertEqual(fileManager.contents(atPath: destination.pathString), anyContent.data(using: .utf8))
+    }
+
+    // MARK: - Private
+
+    private func makeTemporaryFile() throws -> URL {
+        let path = directory.path.appending(component: "\(UUID().uuidString).ipsw")
+        try anyContent.write(to: path.asURL, atomically: true, encoding: .utf8)
+        return path.asURL
+    }
+
+    private var anyContent: String {
+        "TestContent"
+    }
+
+    private var anyRestoreImage: RestoreImage {
+        .init(
+            url: anySourceURL,
+            isSupported: true,
+            buildVersion: anyBuildVersion,
+            operatingSystemVersion: anyOperatingSystemVersion
+        )
+    }
+
+    private var anySourceURL: URL {
+        URL(string: "https://apple.com/images/sample1")!
+    }
+
+    private var anyBuildVersion: String {
+        "E10A"
+    }
+
+    private var anyOperatingSystemVersion: String {
+        "14.5"
+    }
+
+    private func anyDownload() throws -> MockHTTPClient.MockDownload {
+        try .init(url: makeTemporaryFile(), response: URLResponse(), progress: [
+            .init(received: .init(bytes: 10), expected: .init(bytes: 100), progress: 0.1),
+            .init(received: .init(bytes: 70), expected: .init(bytes: 100), progress: 0.7),
+            .init(received: .init(bytes: 90), expected: .init(bytes: 100), progress: 0.9),
+        ])
+    }
+}


### PR DESCRIPTION
- Refactored the interactor to be able to unit test it
- Introduced new `RunLoop` type that is capable of holding the process alive and allows to terminate it gracefully without relying on system `exit()`

Test Plan:
- Ensure all CI checks pass
- Run `curie download -p file.ipsw` locally, verify the download process works without any issues and can be interrupted 