### PR TITLE
Update SwiftCommons to 0.2.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mobileinf/SwiftCommons.git",
       "state" : {
-        "revision" : "623d53c7a114f04830a0c526f1683e7645b05c93",
-        "version" : "0.2.0"
+        "revision" : "00f59a7cbed527907de3b7c05977f21e06f58f01",
+        "version" : "0.2.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .macOS(.v13),
     ],
     dependencies: [
-        .package(url: "https://github.com/mobileinf/SwiftCommons.git", .upToNextMajor(from: "0.2.0")),
+        .package(url: "https://github.com/mobileinf/SwiftCommons.git", .upToNextMajor(from: "0.2.1")),
         .package(url: "https://github.com/apple/swift-tools-support-core", .upToNextMajor(from: "0.5.2")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.2.3")),
     ],


### PR DESCRIPTION
The dependency graph errors should be easier to investigate since the expection reason will contain both type and the name of the missing dependency.

Test Plan:
- Ensure all CI checks pass