### PR TITLE
Add support for pull and push plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,25 @@ mount_virtiofs curie shared
 
 By default, curie stores images and containers in `~/.curie` directory. You can change the location by setting `CURIE_DATA_ROOT` environment variable.
 
+### Pull and Push Images
+
+Curie does not natively support interacting with image registries (such as OCI), but it provides a flexible plugin system that allows you to extend its functionality. By creating lightweight plugins, you can easily add `pull` and `push` commands to interact with external image registries or storage backends.
+
+This plugin system abstracts the integration entirely. Whether you are working with an OCI registry, an S3 bucket, or any other storage solution, the choice is yours. The image handling logic is completely within your control.
+
+#### How to Add `pull` and `push` Plugins
+
+To extend Curie with `pull` and/or `push` commands, follow these steps:
+
+1. Navigate to the `~/.curie` directory (or your custom data directory if `CURIE_DATA_ROOT` is set).
+2. Create a `plugins` directory inside.
+3. Add executable files named `pull` and/or `push` to this directory.
+
+Once these executable files are in place, Curie will automatically recognize them and include the new commands in its `--help` output. When a user runs a `pull` or `push` command, Curie will call the corresponding plugin scripts:
+
+- `push --reference <reference>` will be executed when the user runs `curie push <reference>`.
+- `pull --reference <reference>` will be executed when the user runs `curie pull <reference>`.
+
 ## Development
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -324,6 +324,37 @@ Once these executable files are in place, Curie will automatically recognize the
 - `push --reference <reference>` will be executed when the user runs `curie push <reference>`.
 - `pull --reference <reference>` will be executed when the user runs `curie pull <reference>`.
 
+#### Pull Plugin Example
+
+The following example shows a basic integration with [geranos](https://github.com/mobileinf/geranos).
+
+```bash
+#!/bin/bash -e
+
+# Check if the number of arguments
+if [[ $# -lt 2 ]]; then
+    echo "Error: reference argument is required"
+    echo "Usage: $0 --reference <reference>"
+    exit 1
+fi
+
+# Check if the first argument is "--reference"
+if [ "$1" != "--reference" ]; then
+    echo "Error: reference argument is required"
+    echo "Usage: $0 --reference <reference>"
+    exit 1
+fi
+
+# Check if geranos is installed
+if ! command -v geranos &> /dev/null; then
+    echo "Error: geranos is not installed."
+    exit 1
+fi
+
+# Call geranos
+geranos pull "$2"
+```
+
 ## Development
 
 ### Requirements

--- a/Sources/CurieCommand/Command+Setup.swift
+++ b/Sources/CurieCommand/Command+Setup.swift
@@ -39,6 +39,10 @@ enum Setup {
         (StartCommand.self, StartCommand.Assembly()),
         (VersionCommand.self, VersionCommand.Assembly()),
     ]
+    
+    static let allRuntimeCommands: [(ParsableCommand.Type, Assembly)] = [
+        (PullCommand.self, PullCommand.Assembly())
+    ]
 
     @discardableResult
     static func resolver(with container: DefaultContainer) -> Resolver {
@@ -70,12 +74,20 @@ enum Setup {
 
 extension Command {
     var resolver: Resolver {
-        Setup.resolver(with: DefaultContainer())
+        Shared.resolver
     }
 }
 
 extension ParsableCommand {
     static var allSubcommands: [ParsableCommand.Type] {
-        Setup.allSubcommands.map(\.0)
+        (Setup.allSubcommands.map(\.0) + runtimeSubcommands).sorted { $0._commandName < $1._commandName }
     }
+    
+    static var runtimeSubcommands: [ParsableCommand.Type] {
+        Setup.allRuntimeCommands.filter { $0.0._commandName == "Test" }.map { $0.0 }
+    }
+}
+
+private enum Shared {
+    static let resolver = Setup.resolver(with: DefaultContainer())
 }

--- a/Sources/CurieCommand/Command+Setup.swift
+++ b/Sources/CurieCommand/Command+Setup.swift
@@ -39,9 +39,9 @@ enum Setup {
         (StartCommand.self, StartCommand.Assembly()),
         (VersionCommand.self, VersionCommand.Assembly()),
     ]
-    
+
     static let allRuntimeCommands: [(ParsableCommand.Type, Assembly)] = [
-        (PullCommand.self, PullCommand.Assembly())
+        (PullCommand.self, PullCommand.Assembly()),
     ]
 
     @discardableResult
@@ -82,9 +82,9 @@ extension ParsableCommand {
     static var allSubcommands: [ParsableCommand.Type] {
         (Setup.allSubcommands.map(\.0) + runtimeSubcommands).sorted { $0._commandName < $1._commandName }
     }
-    
+
     static var runtimeSubcommands: [ParsableCommand.Type] {
-        Setup.allRuntimeCommands.filter { $0.0._commandName == "Test" }.map { $0.0 }
+        Setup.allRuntimeCommands.filter { $0.0._commandName == "Test" }.map(\.0)
     }
 }
 

--- a/Sources/CurieCommand/CommandRunner.swift
+++ b/Sources/CurieCommand/CommandRunner.swift
@@ -34,7 +34,7 @@ private struct MainCommand: ParsableCommand {
         commandName: "curie",
         subcommands: MainCommand.allSubcommands
     )
-    
+
     func run() throws {
         _ = MainCommand.run(with: ["--help"])
     }

--- a/Sources/CurieCommand/CommandRunner.swift
+++ b/Sources/CurieCommand/CommandRunner.swift
@@ -34,7 +34,7 @@ private struct MainCommand: ParsableCommand {
         commandName: "curie",
         subcommands: MainCommand.allSubcommands
     )
-
+    
     func run() throws {
         _ = MainCommand.run(with: ["--help"])
     }

--- a/Sources/CurieCommand/Commands/PullCommand.swift
+++ b/Sources/CurieCommand/Commands/PullCommand.swift
@@ -30,7 +30,6 @@ struct PullCommand: Command {
     @Argument(help: "Reference \(CurieCore.Constants.referenceFormat).")
     var reference: String
 
-
     final class Executor: CommandExecutor {
         private let interactor: Interactor
 
@@ -38,14 +37,12 @@ struct PullCommand: Command {
             self.interactor = interactor
         }
 
-        func execute(command: PullCommand) throws {
+        func execute(command _: PullCommand) throws {
             print("Pull...")
         }
     }
 
     final class Assembly: CommandAssembly {
-        func assemble(_ registry: Registry) {
-            
-        }
+        func assemble(_: Registry) {}
     }
 }

--- a/Sources/CurieCommand/Commands/PullCommand.swift
+++ b/Sources/CurieCommand/Commands/PullCommand.swift
@@ -1,0 +1,51 @@
+//
+// Copyright 2024 Marcin Iwanicki, Tomasz Jarosik, and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import ArgumentParser
+import CurieCommon
+import CurieCore
+import Foundation
+import SCInject
+import TSCBasic
+
+struct PullCommand: Command {
+    static let configuration: CommandConfiguration = .init(
+        commandName: "pull",
+        abstract: "Pull image from OCI registry."
+    )
+
+    @Argument(help: "Reference \(CurieCore.Constants.referenceFormat).")
+    var reference: String
+
+
+    final class Executor: CommandExecutor {
+        private let interactor: Interactor
+
+        init(interactor: Interactor) {
+            self.interactor = interactor
+        }
+
+        func execute(command: PullCommand) throws {
+            print("Pull...")
+        }
+    }
+
+    final class Assembly: CommandAssembly {
+        func assemble(_ registry: Registry) {
+            
+        }
+    }
+}

--- a/Sources/CurieCommand/Commands/PullCommand.swift
+++ b/Sources/CurieCommand/Commands/PullCommand.swift
@@ -24,7 +24,7 @@ import TSCBasic
 struct PullCommand: Command {
     static let configuration: CommandConfiguration = .init(
         commandName: Plugin.pull.rawValue,
-        abstract: "Pull image from OCI registry."
+        abstract: "Pull image from registry."
     )
 
     @Argument(help: "Reference \(CurieCore.Constants.referenceFormat).")

--- a/Sources/CurieCommand/Commands/PushCommand.swift
+++ b/Sources/CurieCommand/Commands/PushCommand.swift
@@ -21,10 +21,10 @@ import Foundation
 import SCInject
 import TSCBasic
 
-struct PullCommand: Command {
+struct PushCommand: Command {
     static let configuration: CommandConfiguration = .init(
-        commandName: Plugin.pull.rawValue,
-        abstract: "Pull image from OCI registry."
+        commandName: Plugin.push.rawValue,
+        abstract: "Push image to OCI registry."
     )
 
     @Argument(help: "Reference \(CurieCore.Constants.referenceFormat).")
@@ -37,8 +37,8 @@ struct PullCommand: Command {
             self.interactor = interactor
         }
 
-        func execute(command: PullCommand) throws {
-            try interactor.execute(.pull(.init(reference: command.reference)))
+        func execute(command: PushCommand) throws {
+            try interactor.execute(.push(.init(reference: command.reference)))
         }
     }
 

--- a/Sources/CurieCommand/Commands/PushCommand.swift
+++ b/Sources/CurieCommand/Commands/PushCommand.swift
@@ -24,7 +24,7 @@ import TSCBasic
 struct PushCommand: Command {
     static let configuration: CommandConfiguration = .init(
         commandName: Plugin.push.rawValue,
-        abstract: "Push image to OCI registry."
+        abstract: "Push image to registry."
     )
 
     @Argument(help: "Reference \(CurieCore.Constants.referenceFormat).")

--- a/Sources/CurieCommon/FileSystem.swift
+++ b/Sources/CurieCommon/FileSystem.swift
@@ -74,6 +74,14 @@ public final class DefaultFileSystem: FileSystem {
         public struct Overrides {
             var currentWorkingDirectory: AbsolutePath?
             var homeDirectory: AbsolutePath?
+
+            public init(
+                currentWorkingDirectory: AbsolutePath? = nil,
+                homeDirectory: AbsolutePath? = nil
+            ) {
+                self.currentWorkingDirectory = currentWorkingDirectory
+                self.homeDirectory = homeDirectory
+            }
         }
 
         var overrides: Overrides = .init()

--- a/Sources/CurieCommonMocks/MockSystem.swift
+++ b/Sources/CurieCommonMocks/MockSystem.swift
@@ -19,6 +19,7 @@ import Foundation
 
 public final class MockSystem: System {
     public enum Call: Equatable {
+        case execute([String])
         case executeWithOutput([String])
     }
 
@@ -51,8 +52,8 @@ public final class MockSystem: System {
         fatalError("Not implemented yet")
     }
 
-    public func execute(_: [String]) throws {
-        fatalError("Not implemented yet")
+    public func execute(_ arguments: [String]) throws {
+        calls.append(.execute(arguments))
     }
 
     public func execute(_ arguments: [String], output: CurieCommon.OutputType) throws {

--- a/Sources/CurieCore/Assembly/CoreAssembly.swift
+++ b/Sources/CurieCore/Assembly/CoreAssembly.swift
@@ -42,6 +42,8 @@ public final class CoreAssembly: Assembly {
                 imagesInteractor: r.resolve(ImagesInteractor.self),
                 importInteractor: r.resolve(ImportInteractor.self),
                 inspectInteractor: r.resolve(InspectInteractor.self),
+                pullInteractor: r.resolve(PullInteractor.self),
+                pushInteractor: r.resolve(PushInteractor.self),
                 psInteractor: r.resolve(PsInteractor.self),
                 rmiInteractor: r.resolve(RmiInteractor.self),
                 rmInteractor: r.resolve(RmInteractor.self),
@@ -118,6 +120,18 @@ public final class CoreAssembly: Assembly {
             CommitInteractor(
                 configurator: r.resolve(VMConfigurator.self),
                 imageCache: r.resolve(ImageCache.self),
+                console: r.resolve(Console.self)
+            )
+        }
+        registry.register(PullInteractor.self) { r in
+            PullInteractor(
+                pluginExecutor: r.resolve(PluginExecutor.self),
+                console: r.resolve(Console.self)
+            )
+        }
+        registry.register(PushInteractor.self) { r in
+            PushInteractor(
+                pluginExecutor: r.resolve(PluginExecutor.self),
                 console: r.resolve(Console.self)
             )
         }
@@ -203,6 +217,13 @@ public final class CoreAssembly: Assembly {
         }
         registry.register(RestoreImageService.self) { _ in
             DefaultRestoreImageService()
+        }
+        registry.register(PluginExecutor.self) { r in
+            DefaultPluginExecutor(
+                system: r.resolve(System.self),
+                fileSystem: r.resolve(FileSystem.self),
+                console: r.resolve(Console.self)
+            )
         }
     }
 }

--- a/Sources/CurieCore/Config/PluginExecutor.swift
+++ b/Sources/CurieCore/Config/PluginExecutor.swift
@@ -1,0 +1,95 @@
+//
+// Copyright 2024 Marcin Iwanicki, Tomasz Jarosik, and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import CurieCommon
+import Foundation
+import TSCBasic
+
+public enum Plugin: String {
+    case pull
+    case push
+}
+
+public protocol PluginExecutor {
+    func supportsCommand(_ command: String) -> Bool
+    func executePlugin(_ plugin: Plugin, parameters: [String: String]) throws
+}
+
+final class DefaultPluginExecutor: PluginExecutor {
+    private let system: System
+    private let fileSystem: CurieCommon.FileSystem
+    private let console: Console
+
+    init(
+        system: System,
+        fileSystem: CurieCommon.FileSystem,
+        console: Console
+    ) {
+        self.system = system
+        self.fileSystem = fileSystem
+        self.console = console
+    }
+
+    func supportsCommand(_ command: String) -> Bool {
+        let pluginsDirectory = pluginsDirectory()
+        guard let list = try? fileSystem.list(at: pluginsDirectory) else {
+            return false
+        }
+        return list
+            .compactMap {
+                switch $0 {
+                case let .file(file):
+                    file.path.basename
+                default:
+                    nil
+                }
+            }
+            .contains { $0 == command }
+    }
+
+    func executePlugin(_ plugin: Plugin, parameters: [String: String]) throws {
+        let executablePath = pluginsDirectory().appending(component: plugin.rawValue)
+        guard fileSystem.exists(at: executablePath) else {
+            console.error("Plugin does not exist at '\(executablePath)'")
+            return
+        }
+        guard fileSystem.isFile(at: executablePath) else {
+            console.error("Plugin at '\(executablePath)' is not a file")
+            return
+        }
+        guard fileSystem.isExecutable(at: executablePath) else {
+            console.error("Plugin at '\(executablePath)' is not executable")
+            return
+        }
+        let commandParameters = parameters
+            .sorted(by: { $0.key < $1.key })
+            .flatMap { ["--\($0.key)", $0.value] }
+        let command = [executablePath.pathString] + commandParameters
+
+        try system.execute(command)
+    }
+
+    // MARK: - Private
+
+    // TODO: Extract and share with ImageCache
+    private func pluginsDirectory() -> AbsolutePath {
+        if let overrideDataRootString = system.environmentVariable(name: Constants.dataRootEnvironmentVariable) {
+            return fileSystem.absolutePath(from: overrideDataRootString)
+        }
+        return fileSystem.homeDirectory
+            .appending(components: [".curie", "plugins"])
+    }
+}

--- a/Sources/CurieCore/Interactor.swift
+++ b/Sources/CurieCore/Interactor.swift
@@ -27,6 +27,8 @@ public enum Operation {
     case images(ImagesParameters)
     case `import`(ImportParameters)
     case inspect(InspectParameters)
+    case pull(PullParameters)
+    case push(PushParameters)
     case ps(PsParameters)
     case rmi(RmiParameters)
     case rm(RmParameters)
@@ -53,6 +55,8 @@ final class DefaultInteractor: Interactor {
     private let imagesInteractor: ImagesInteractor
     private let importInteractor: ImportInteractor
     private let inspectInteractor: InspectInteractor
+    private let pullInteractor: PullInteractor
+    private let pushInteractor: PushInteractor
     private let psInteractor: PsInteractor
     private let rmiInteractor: RmiInteractor
     private let rmInteractor: RmInteractor
@@ -69,6 +73,8 @@ final class DefaultInteractor: Interactor {
         imagesInteractor: ImagesInteractor,
         importInteractor: ImportInteractor,
         inspectInteractor: InspectInteractor,
+        pullInteractor: PullInteractor,
+        pushInteractor: PushInteractor,
         psInteractor: PsInteractor,
         rmiInteractor: RmiInteractor,
         rmInteractor: RmInteractor,
@@ -84,6 +90,8 @@ final class DefaultInteractor: Interactor {
         self.imagesInteractor = imagesInteractor
         self.importInteractor = importInteractor
         self.inspectInteractor = inspectInteractor
+        self.pullInteractor = pullInteractor
+        self.pushInteractor = pushInteractor
         self.psInteractor = psInteractor
         self.rmiInteractor = rmiInteractor
         self.rmInteractor = rmInteractor
@@ -114,6 +122,10 @@ final class DefaultInteractor: Interactor {
                 try await importInteractor.execute(parameters: parameters)
             case let .inspect(parameters):
                 try await inspectInteractor.execute(parameters: parameters)
+            case let .pull(parameters):
+                try await pullInteractor.execute(parameters: parameters)
+            case let .push(parameters):
+                try await pushInteractor.execute(parameters: parameters)
             case let .ps(parameters):
                 try await psInteractor.execute(parameters: parameters)
             case let .rmi(parameters):

--- a/Sources/CurieCore/Interactors/PullInteractor.swift
+++ b/Sources/CurieCore/Interactors/PullInteractor.swift
@@ -1,0 +1,43 @@
+//
+// Copyright 2024 Marcin Iwanicki, Tomasz Jarosik, and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import CurieCommon
+import Foundation
+
+public struct PullParameters {
+    public let reference: String
+
+    public init(reference: String) {
+        self.reference = reference
+    }
+}
+
+final class PullInteractor: AsyncInteractor {
+    private let pluginExecutor: PluginExecutor
+    private let console: Console
+
+    init(
+        pluginExecutor: PluginExecutor,
+        console: Console
+    ) {
+        self.pluginExecutor = pluginExecutor
+        self.console = console
+    }
+
+    func execute(parameters: PullParameters) async throws {
+        try pluginExecutor.executePlugin(.pull, parameters: ["reference": parameters.reference])
+    }
+}

--- a/Sources/CurieCore/Interactors/PushInteractor.swift
+++ b/Sources/CurieCore/Interactors/PushInteractor.swift
@@ -1,0 +1,43 @@
+//
+// Copyright 2024 Marcin Iwanicki, Tomasz Jarosik, and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import CurieCommon
+import Foundation
+
+public struct PushParameters {
+    public let reference: String
+
+    public init(reference: String) {
+        self.reference = reference
+    }
+}
+
+final class PushInteractor: AsyncInteractor {
+    private let pluginExecutor: PluginExecutor
+    private let console: Console
+
+    init(
+        pluginExecutor: PluginExecutor,
+        console: Console
+    ) {
+        self.pluginExecutor = pluginExecutor
+        self.console = console
+    }
+
+    func execute(parameters: PushParameters) async throws {
+        try pluginExecutor.executePlugin(.push, parameters: ["reference": parameters.reference])
+    }
+}

--- a/Sources/CurieCoreTests/Interactors/BuildInteractorTests.swift
+++ b/Sources/CurieCoreTests/Interactors/BuildInteractorTests.swift
@@ -26,21 +26,16 @@ import XCTest
 final class BuildInteractorTests: XCTestCase {
     private var subject: Interactor!
     private var env: InteractorsTestsEnvironment!
-    private var directory: TemporaryDirectory!
-
-    private let fileManager = FileManager.default
 
     override func setUpWithError() throws {
         super.setUp()
         env = InteractorsTestsEnvironment()
-        directory = try TemporaryDirectory()
         subject = env.resolveInteractor()
     }
 
     override func tearDown() {
         super.tearDown()
         env = nil
-        directory = nil
         subject = nil
     }
 

--- a/Sources/CurieCoreTests/Interactors/PullInteractorTests.swift
+++ b/Sources/CurieCoreTests/Interactors/PullInteractorTests.swift
@@ -1,0 +1,102 @@
+//
+// Copyright 2024 Marcin Iwanicki, Tomasz Jarosik, and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import CurieCommon
+import CurieCommonMocks
+@testable import CurieCore
+import CurieCoreMocks
+import Foundation
+import SCInject
+import XCTest
+
+final class PullInteractorTests: XCTestCase {
+    private var subject: Interactor!
+    private var env: InteractorsTestsEnvironment!
+
+    override func setUpWithError() throws {
+        super.setUp()
+        env = InteractorsTestsEnvironment()
+        subject = env.resolveInteractor()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        env = nil
+        subject = nil
+    }
+
+    func testPullPluginNotAvailable() throws {
+        // When
+        try subject.execute(.pull(.init(reference: anyReference)))
+
+        // Then
+        XCTAssertEqual(
+            env.console.calls,
+            [.error("Plugin does not exist at '\(pullExecutablePath)'")]
+        )
+    }
+
+    func testPullPluginNotAFile() throws {
+        // Given
+        try env.fileManager.createDirectory(atPath: pullExecutablePath, withIntermediateDirectories: true)
+
+        // When
+        try subject.execute(.pull(.init(reference: anyReference)))
+
+        // Then
+        XCTAssertEqual(
+            env.console.calls,
+            [.error("Plugin at '\(pullExecutablePath)' is not a file")]
+        )
+    }
+
+    func testPullPluginNotExecutable() throws {
+        // Given
+        env.fileManager.createFile(atPath: pullExecutablePath, contents: "".data(using: .utf8)!)
+
+        // When
+        try subject.execute(.pull(.init(reference: anyReference)))
+
+        // Then
+        XCTAssertEqual(
+            env.console.calls,
+            [.error("Plugin at '\(pullExecutablePath)' is not executable")]
+        )
+    }
+
+    func testPullPluginSuccessCall() throws {
+        // Given
+        env.fileManager.createFile(atPath: pullExecutablePath, contents: "".data(using: .utf8)!)
+        try env.fileManager.markAsExecuable(atPath: pullExecutablePath)
+
+        // When
+        try subject.execute(.pull(.init(reference: anyReference)))
+
+        // Then
+        XCTAssertEqual(env.console.calls, [])
+        XCTAssertEqual(env.system.calls, [.execute([pullExecutablePath, "--reference", anyReference])])
+    }
+
+    // MARK: - Private
+
+    private var anyReference: String {
+        "test-reference"
+    }
+
+    private var pullExecutablePath: String {
+        env.fileSystem.homeDirectory.appending(components: [".curie", "plugins", "pull"]).pathString
+    }
+}

--- a/Sources/CurieCoreTests/Interactors/PushInteractorTests.swift
+++ b/Sources/CurieCoreTests/Interactors/PushInteractorTests.swift
@@ -1,0 +1,102 @@
+//
+// Copyright 2024 Marcin Iwanicki, Tomasz Jarosik, and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import CurieCommon
+import CurieCommonMocks
+@testable import CurieCore
+import CurieCoreMocks
+import Foundation
+import SCInject
+import XCTest
+
+final class PushInteractorTests: XCTestCase {
+    private var subject: Interactor!
+    private var env: InteractorsTestsEnvironment!
+
+    override func setUpWithError() throws {
+        super.setUp()
+        env = InteractorsTestsEnvironment()
+        subject = env.resolveInteractor()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        env = nil
+        subject = nil
+    }
+
+    func testPushPluginNotAvailable() throws {
+        // When
+        try subject.execute(.push(.init(reference: anyReference)))
+
+        // Then
+        XCTAssertEqual(
+            env.console.calls,
+            [.error("Plugin does not exist at '\(pushExecutablePath)'")]
+        )
+    }
+
+    func testPushPluginNotAFile() throws {
+        // Given
+        try env.fileManager.createDirectory(atPath: pushExecutablePath, withIntermediateDirectories: true)
+
+        // When
+        try subject.execute(.push(.init(reference: anyReference)))
+
+        // Then
+        XCTAssertEqual(
+            env.console.calls,
+            [.error("Plugin at '\(pushExecutablePath)' is not a file")]
+        )
+    }
+
+    func testPushPluginNotExecutable() throws {
+        // Given
+        env.fileManager.createFile(atPath: pushExecutablePath, contents: "".data(using: .utf8)!)
+
+        // When
+        try subject.execute(.push(.init(reference: anyReference)))
+
+        // Then
+        XCTAssertEqual(
+            env.console.calls,
+            [.error("Plugin at '\(pushExecutablePath)' is not executable")]
+        )
+    }
+
+    func testPushPluginSuccessCall() throws {
+        // Given
+        env.fileManager.createFile(atPath: pushExecutablePath, contents: "".data(using: .utf8)!)
+        try env.fileManager.markAsExecuable(atPath: pushExecutablePath)
+
+        // When
+        try subject.execute(.push(.init(reference: anyReference)))
+
+        // Then
+        XCTAssertEqual(env.console.calls, [])
+        XCTAssertEqual(env.system.calls, [.execute([pushExecutablePath, "--reference", anyReference])])
+    }
+
+    // MARK: - Private
+
+    private var anyReference: String {
+        "test-reference"
+    }
+
+    private var pushExecutablePath: String {
+        env.fileSystem.homeDirectory.appending(components: [".curie", "plugins", "push"]).pathString
+    }
+}


### PR DESCRIPTION
New `pull` and `push` commands allow users to easily interact with image registries.

Test Plan:
- Ensure all CI checks pass
- Create new pull plugin and verify the plugin is visible in `curie --help` and you can call it without any issues
- Create new push plugin and verify the plugin is visible in `curie --help` and you can call it without any issues 