### PR TITLE
Fix release script

### DIFF
--- a/.mise/tasks/release
+++ b/.mise/tasks/release
@@ -27,11 +27,6 @@ CURIE_P8_PATH="$CURIE_TEMP_DIR/curie-authkey.p8"
 CURIE_PKG_BUNDLE_ID="com.curievm.curie"
 CURIE_PKG_DIR="$CURIE_TEMP_DIR/pkg-package"
 
-function clean() {
-    rm -f "$CURIE_CHECKSUMS_PATH"
-    touch "$CURIE_CHECKSUMS_PATH"
-}
-
 function load_envvars_if_possible() {
     CURIE_CREDENTIALS_PATH="$MISE_PROJECT_ROOT/.credentials/release-credentials"
     if [ -e "$CURIE_CREDENTIALS_PATH" ]; then
@@ -192,7 +187,6 @@ function prepare_pkg() {
 }
 
 function main() {
-    clean
     load_envvars_if_possible
     validate_envvars
     set_up

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test:
 sign:
 	@$(mise) run sign
 
-release:
+release: clean
 	@$(mise) run release
 
 format:


### PR DESCRIPTION
Old implementation was working under invalid assumption that `.build` directory already exists when `release` script is called.
```
touch: /Users/marcin/Projects/macvmio/curie/.build/checksums.txt: No such file or directory
mise ~/Projects/macvmio/curie/.mise/tasks/release exited with non-zero status: exit code 1
make: *** [release] Error 1
```

Test Plan:
- Ensure all CI checks pass
- Verify `make release` completes locally without any issues