### PR TITLE
Update dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
-        "version" : "1.2.3"
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
       }
     },
     {
@@ -14,23 +14,23 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "836bc4557b74fe6d2660218d56e3ce96aff76574",
-        "version" : "1.1.1"
+        "revision" : "d2ba781702a1d8285419c15ee62fd734a9437ff5",
+        "version" : "1.3.2"
       }
     },
     {
       "identity" : "swift-tools-support-core",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-tools-support-core.git",
+      "location" : "https://github.com/apple/swift-tools-support-core",
       "state" : {
-        "revision" : "93784c59434dbca8e8a9e4b700d0d6d94551da6a",
-        "version" : "0.5.2"
+        "revision" : "3b13e439a341bbbfe0f710c7d1be37221745ef1a",
+        "version" : "0.6.1"
       }
     },
     {
       "identity" : "swiftcommons",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mobileinf/SwiftCommons.git",
+      "location" : "https://github.com/macvmio/SwiftCommons.git",
       "state" : {
         "revision" : "00f59a7cbed527907de3b7c05977f21e06f58f01",
         "version" : "0.2.1"

--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/macvmio/SwiftCommons.git", .upToNextMajor(from: "0.2.1")),
-        .package(url: "https://github.com/apple/swift-tools-support-core", .upToNextMajor(from: "0.5.2")),
-        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.2.3")),
+        .package(url: "https://github.com/apple/swift-tools-support-core", .upToNextMajor(from: "0.6.1")),
+        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.5.0")),
     ],
     targets: [
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .macOS(.v13),
     ],
     dependencies: [
-        .package(url: "https://github.com/mobileinf/SwiftCommons.git", .upToNextMajor(from: "0.2.1")),
+        .package(url: "https://github.com/macvmio/SwiftCommons.git", .upToNextMajor(from: "0.2.1")),
         .package(url: "https://github.com/apple/swift-tools-support-core", .upToNextMajor(from: "0.5.2")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.2.3")),
     ],


### PR DESCRIPTION
- Update path to SwiftCommons
- Bump swift-tools-support-core to 0.6.1
- Bump swift-argument-parser to 1.5.0

Test Plan:
- Ensure all CI checks pass