### PR TITLE
Fix mise config

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -4,5 +4,5 @@ swiftformat = "0.53.3"
 
 [settings]
 jobs = 6
-http_timeout = 30
+http_timeout = "30"
 experimental = true


### PR DESCRIPTION
The error I was getting locally:
```
   0: error parsing config file: ~/Projects/macvmio/curie/.mise.toml
   1: TOML parse error at line 7, column 16
   1:   |
   1: 7 | http_timeout = 30
   1:   |                ^^
   1: invalid type: integer `30`, expected a string
```

Test Plan:
- Ensure all CI checks pass