### PR TITLE
Fix link to license file

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,4 +402,4 @@ We would like to thank the authors and contributors of the following projects:
 
 ## License
 
-Curie is released under version 2.0 of the [Apache License](LICENSE.txt).
+Curie is released under version 2.0 of the [Apache License](LICENSE).


### PR DESCRIPTION
Test Plan:
- Verify "Apache License" link in README points to the LICENSE file