### PR TITLE
Use synthesized MAC address by default

### DIFF
--- a/Sources/CurieCore/Config/Constrants.swift
+++ b/Sources/CurieCore/Config/Constrants.swift
@@ -27,7 +27,7 @@ public enum Constants {
         memorySize: .init(bytes: 4 * 1024 * 1024 * 1024),
         display: .init(width: 1920, height: 1080, pixelsPerInch: 144),
         network: .init(devices: [
-            .init(macAddress: .automatic, mode: .NAT),
+            .init(macAddress: .synthesized, mode: .NAT),
         ]),
         sharedDirectory: .init(directories: []),
         shutdown: .init(behaviour: .stop)


### PR DESCRIPTION
Test Plan:
- Create new image and verify the MAC address of the container is synthesized, IP address is automatically assigned and inspectable via `curie inspect`