### PR TITLE
Use modern initializer for RelativePath

### DIFF
--- a/Sources/CurieCommon/Directory.swift
+++ b/Sources/CurieCommon/Directory.swift
@@ -36,7 +36,7 @@ public final class TemporaryDirectory: Directory {
     private let fileManager = FileManager.default
 
     public init() throws {
-        let path = try determineTempDirectory(nil).appending(RelativePath("curie.XXXXXX"))
+        let path = try determineTempDirectory(nil).appending(try RelativePath(validating: "curie.XXXXXX"))
 
         // Convert path to a C style string terminating with null char to be an valid input
         // to mkdtemp method. The XXXXXX in this string will be replaced by a random string

--- a/Sources/CurieCommon/Directory.swift
+++ b/Sources/CurieCommon/Directory.swift
@@ -36,7 +36,7 @@ public final class TemporaryDirectory: Directory {
     private let fileManager = FileManager.default
 
     public init() throws {
-        let path = try determineTempDirectory(nil).appending(try RelativePath(validating: "curie.XXXXXX"))
+        let path = try determineTempDirectory(nil).appending(RelativePath(validating: "curie.XXXXXX"))
 
         // Convert path to a C style string terminating with null char to be an valid input
         // to mkdtemp method. The XXXXXX in this string will be replaced by a random string

--- a/Sources/CurieCommon/FileSystem.swift
+++ b/Sources/CurieCommon/FileSystem.swift
@@ -129,7 +129,7 @@ public final class DefaultFileSystem: FileSystem {
     public func list(at path: AbsolutePath) throws -> [FileSystemItem] {
         try fileManager.contentsOfDirectory(atPath: path.pathString)
             .sorted()
-            .map { RelativePath($0) }
+            .map { try RelativePath(validating: $0) }
             .map {
                 let absolutePath = path.appending($0)
                 var isDir: ObjCBool = false

--- a/Sources/CurieCore/Cache/ImageCache.swift
+++ b/Sources/CurieCore/Cache/ImageCache.swift
@@ -47,8 +47,8 @@ protocol ImageCache {
     @discardableResult
     func cloneImage(source: ImageReference, target: Target) throws -> ImageReference
     func moveImage(source: ImageReference, target: ImageReference) throws
-    func path(to reference: ImageReference) -> AbsolutePath
-    func bundle(for reference: ImageReference) -> VMBundle
+    func path(to reference: ImageReference) throws -> AbsolutePath
+    func bundle(for reference: ImageReference) throws -> VMBundle
 
     func exportImage(source: ImageReference, destinationPath: String, mode: ExportMode) throws
     func importImage(sourcePath: String, reference: String) throws
@@ -79,7 +79,7 @@ final class DefaultImageCache: ImageCache {
                 .generic("Cannot create empty reference, please use (\(CurieCore.Constants.referenceFormat)) format")
         }
         let descriptor = try ImageDescriptor(reference: reference)
-        let relativePath = RelativePath(reference)
+        let relativePath = try RelativePath(validating: reference)
         let absolutePath = imagesAbsolutePath().appending(relativePath)
         guard !fileSystem.exists(at: absolutePath) else {
             throw CoreError
@@ -121,7 +121,7 @@ final class DefaultImageCache: ImageCache {
     }
 
     func removeImage(_ reference: ImageReference) throws {
-        let absolutePath = path(to: reference)
+        let absolutePath = try path(to: reference)
         try fileSystem.remove(at: absolutePath)
         try removeEmptySubdirectories(of: imagesAbsolutePath())
         try removeEmptySubdirectories(of: containersAbsolutePath())
@@ -129,11 +129,11 @@ final class DefaultImageCache: ImageCache {
 
     @discardableResult
     func cloneImage(source: ImageReference, target: Target) throws -> ImageReference {
-        let sourceAbsolutePath = path(to: source)
+        let sourceAbsolutePath = try path(to: source)
         let targetId = ImageID.make()
         let targetDescriptor = try target.imageDescriptor(source: source, imageId: targetId)
         let targetReference = ImageReference(id: targetId, descriptor: targetDescriptor, type: target.imageType())
-        let targetAbsolutePath = path(to: targetReference)
+        let targetAbsolutePath = try path(to: targetReference)
         guard sourceAbsolutePath != targetAbsolutePath else {
             throw CoreError.generic("Cannot clone, target reference is the same as source")
         }
@@ -150,8 +150,8 @@ final class DefaultImageCache: ImageCache {
     }
 
     func moveImage(source: ImageReference, target: ImageReference) throws {
-        let sourceAbsolutePath = path(to: source)
-        let targetAbsolutePath = path(to: target)
+        let sourceAbsolutePath = try path(to: source)
+        let targetAbsolutePath = try path(to: target)
 
         if fileSystem.exists(at: targetAbsolutePath) {
             try fileSystem.remove(at: targetAbsolutePath)
@@ -166,16 +166,16 @@ final class DefaultImageCache: ImageCache {
         try removeEmptySubdirectories(of: containersAbsolutePath())
     }
 
-    func path(to reference: ImageReference) -> AbsolutePath {
-        storeAbsolutePath(reference.type).appending(reference.descriptor.relativePath())
+    func path(to reference: ImageReference) throws -> AbsolutePath {
+        storeAbsolutePath(reference.type).appending(try reference.descriptor.relativePath())
     }
 
-    func bundle(for reference: ImageReference) -> VMBundle {
-        VMBundle(path: path(to: reference))
+    func bundle(for reference: ImageReference) throws -> VMBundle {
+        VMBundle(path: try path(to: reference))
     }
 
     func exportImage(source: ImageReference, destinationPath: String, mode: ExportMode) throws {
-        let sourceAbsolutePath = path(to: source)
+        let sourceAbsolutePath = try path(to: source)
         let targetAbsolutePath = fileSystem.absolutePath(from: destinationPath)
         if fileSystem.exists(at: targetAbsolutePath) {
             guard try fileSystem.list(at: targetAbsolutePath).isEmpty else {
@@ -209,7 +209,7 @@ final class DefaultImageCache: ImageCache {
         }
 
         let targetReference = try makeImageReference(reference)
-        let targetAbsolutePath = path(to: targetReference)
+        let targetAbsolutePath = try path(to: targetReference)
 
         try fileSystem.createDirectory(at: targetAbsolutePath.parentDirectory)
 
@@ -240,7 +240,7 @@ final class DefaultImageCache: ImageCache {
 
     private func items(from references: [ImageReference]) throws -> [ImageItem] {
         let items = try references.map {
-            let bundle = bundle(for: $0)
+            let bundle = try bundle(for: $0)
             let metadata = try bundleParser.readMetadata(from: bundle)
             return try ImageItem(
                 reference: $0,
@@ -272,7 +272,7 @@ final class DefaultImageCache: ImageCache {
 
     private func findReference(_ reference: String, type: ImageType) throws -> ImageReference {
         let descriptor = try ImageDescriptor(reference: reference)
-        let absolutePath = storeAbsolutePath(type).appending(descriptor.relativePath())
+        let absolutePath = storeAbsolutePath(type).appending(try descriptor.relativePath())
         guard fileSystem.exists(at: absolutePath) else {
             switch type {
             case .container:
@@ -369,11 +369,11 @@ final class DefaultImageCache: ImageCache {
 }
 
 private extension ImageDescriptor {
-    func relativePath() -> RelativePath {
+    func relativePath() throws -> RelativePath {
         if let tag {
-            RelativePath("\(repository):\(tag)")
+            try RelativePath(validating: "\(repository):\(tag)")
         } else {
-            RelativePath(repository)
+            try RelativePath(validating: repository)
         }
     }
 }

--- a/Sources/CurieCore/Cache/ImageCache.swift
+++ b/Sources/CurieCore/Cache/ImageCache.swift
@@ -167,11 +167,11 @@ final class DefaultImageCache: ImageCache {
     }
 
     func path(to reference: ImageReference) throws -> AbsolutePath {
-        storeAbsolutePath(reference.type).appending(try reference.descriptor.relativePath())
+        try storeAbsolutePath(reference.type).appending(reference.descriptor.relativePath())
     }
 
     func bundle(for reference: ImageReference) throws -> VMBundle {
-        VMBundle(path: try path(to: reference))
+        try VMBundle(path: path(to: reference))
     }
 
     func exportImage(source: ImageReference, destinationPath: String, mode: ExportMode) throws {
@@ -272,7 +272,7 @@ final class DefaultImageCache: ImageCache {
 
     private func findReference(_ reference: String, type: ImageType) throws -> ImageReference {
         let descriptor = try ImageDescriptor(reference: reference)
-        let absolutePath = storeAbsolutePath(type).appending(try descriptor.relativePath())
+        let absolutePath = try storeAbsolutePath(type).appending(descriptor.relativePath())
         guard fileSystem.exists(at: absolutePath) else {
             switch type {
             case .container:

--- a/Sources/CurieCore/Interactors/BuildInteractor.swift
+++ b/Sources/CurieCore/Interactors/BuildInteractor.swift
@@ -57,7 +57,7 @@ final class BuildInteractor: AsyncInteractor {
 
     func execute(parameters: BuildParameters) async throws {
         let reference = try imageCache.makeImageReference(parameters.reference)
-        let bundle = imageCache.bundle(for: reference)
+        let bundle = try imageCache.bundle(for: reference)
 
         // Get restore image path
         let restoreImagePath = fileSystem.absolutePath(from: parameters.ipwsPath)

--- a/Sources/CurieCore/Interactors/ConfigInteractor.swift
+++ b/Sources/CurieCore/Interactors/ConfigInteractor.swift
@@ -39,7 +39,7 @@ final class ConfigInteractor: AsyncInteractor {
 
     func execute(parameters: ConfigParameters) async throws {
         let reference = try imageCache.findReference(parameters.reference)
-        let bundle = imageCache.bundle(for: reference)
+        let bundle = try imageCache.bundle(for: reference)
         try system.execute(["open", "-t", bundle.config.pathString])
     }
 }

--- a/Sources/CurieCore/Interactors/CreateInteractor.swift
+++ b/Sources/CurieCore/Interactors/CreateInteractor.swift
@@ -50,7 +50,7 @@ final class CreateInteractor: AsyncInteractor {
         let sourceReference = try imageCache.findImageReference(parameters.reference)
         let targetReference = try imageCache.cloneImage(source: sourceReference, target: .newReference)
 
-        let bundle = imageCache.bundle(for: targetReference)
+        let bundle = try imageCache.bundle(for: targetReference)
         try bundleParser.updateMetadata(bundle: bundle) { metadata in
             metadata.name = parameters.name
         }

--- a/Sources/CurieCore/Interactors/InspectInteractor.swift
+++ b/Sources/CurieCore/Interactors/InspectInteractor.swift
@@ -57,7 +57,7 @@ final class InspectInteractor: AsyncInteractor {
 
     func execute(parameters: InspectParameters) async throws {
         let reference = try imageCache.findReference(parameters.reference)
-        let bundle = imageCache.bundle(for: reference)
+        let bundle = try imageCache.bundle(for: reference)
         let info = try bundleParser.readInfo(from: bundle)
         let arpItems = try aprClient.executeARPQuery()
         let macAddresses = Set(info.metadata.network.flatMap { $0.devices.map(\.value.MACAddress) } ?? [])

--- a/Sources/CurieCore/Interactors/RunInteractor.swift
+++ b/Sources/CurieCore/Interactors/RunInteractor.swift
@@ -63,7 +63,7 @@ public final class DefaultRunInteractor: RunInteractor {
         let sourceReference = try imageCache.findImageReference(context.reference)
         let targetReference = try imageCache.cloneImage(source: sourceReference, target: .newReference)
 
-        let bundle = imageCache.bundle(for: targetReference)
+        let bundle = try imageCache.bundle(for: targetReference)
         let overrideConfig = try context.launch.partialConfig()
         let vm = try configurator.loadVM(with: bundle, overrideConfig: overrideConfig)
         let options = VMStartOptions(

--- a/Sources/CurieCore/Interactors/StartInteractor.swift
+++ b/Sources/CurieCore/Interactors/StartInteractor.swift
@@ -61,7 +61,7 @@ public final class DefaultStartInteractor: StartInteractor {
 
         let sourceReference = try imageCache.findContainerReference(context.reference)
 
-        let bundle = imageCache.bundle(for: sourceReference)
+        let bundle = try imageCache.bundle(for: sourceReference)
         let overrideConfig = try context.launch.partialConfig()
         let vm = try configurator.loadVM(with: bundle, overrideConfig: overrideConfig)
         let options = VMStartOptions(

--- a/Sources/CurieCoreTests/Cache/ImageCacheTests.swift
+++ b/Sources/CurieCoreTests/Cache/ImageCacheTests.swift
@@ -189,7 +189,7 @@ final class ImageCacheTests: XCTestCase {
 
     func testPath() throws {
         // Given
-        let expectedPath = environment.homeDirectory.appending(RelativePath(".curie/.images/\(anyReference)"))
+        let expectedPath = environment.homeDirectory.appending(try RelativePath(validating: ".curie/.images/\(anyReference)"))
 
         // When
         let path = try subject.path(
@@ -207,7 +207,7 @@ final class ImageCacheTests: XCTestCase {
     func testImportImage() throws {
         // Given
         let bundle = try fixtures.makeImageBundle(at: anyBundlePath)
-        let expectedBundlePath = environment.homeDirectory.appending(RelativePath(".curie/.images/\(anyReference)"))
+        let expectedBundlePath = environment.homeDirectory.appending(try RelativePath(validating: ".curie/.images/\(anyReference)"))
 
         // When
         try subject.importImage(sourcePath: bundle.path.pathString, reference: anyReference)
@@ -215,12 +215,12 @@ final class ImageCacheTests: XCTestCase {
         // Then
         let files = try fileSystem.list(at: expectedBundlePath)
         XCTAssertEqual(files, [
-            .file(.init(path: .init("auxilary-storage.bin"))),
-            .file(.init(path: .init("config.json"))),
-            .file(.init(path: .init("disk.img"))),
-            .file(.init(path: .init("hardware-model.bin"))),
-            .file(.init(path: .init("machine-identifier.bin"))),
-            .file(.init(path: .init("metadata.json"))),
+            .file(.init(path: try .init(validating: "auxilary-storage.bin"))),
+            .file(.init(path: try .init(validating: "config.json"))),
+            .file(.init(path: try .init(validating: "disk.img"))),
+            .file(.init(path: try .init(validating: "hardware-model.bin"))),
+            .file(.init(path: try .init(validating: "machine-identifier.bin"))),
+            .file(.init(path: try .init(validating: "metadata.json"))),
         ])
         XCTAssertBundlesEqual(bundle, path: expectedBundlePath)
     }
@@ -232,7 +232,7 @@ final class ImageCacheTests: XCTestCase {
         ]
         let bundle = try fixtures.makeImageBundle(at: anyBundlePath)
         let expectedBundlePath = environment.temporaryDirectory.appending(component: ".curie-custom")
-            .appending(RelativePath(".images/\(anyReference)"))
+            .appending(try RelativePath(validating: ".images/\(anyReference)"))
 
         // When
         try subject.importImage(sourcePath: bundle.path.pathString, reference: anyReference)
@@ -240,12 +240,12 @@ final class ImageCacheTests: XCTestCase {
         // Then
         let files = try fileSystem.list(at: expectedBundlePath)
         XCTAssertEqual(files, [
-            .file(.init(path: .init("auxilary-storage.bin"))),
-            .file(.init(path: .init("config.json"))),
-            .file(.init(path: .init("disk.img"))),
-            .file(.init(path: .init("hardware-model.bin"))),
-            .file(.init(path: .init("machine-identifier.bin"))),
-            .file(.init(path: .init("metadata.json"))),
+            .file(.init(path: try .init(validating: "auxilary-storage.bin"))),
+            .file(.init(path: try .init(validating: "config.json"))),
+            .file(.init(path: try .init(validating: "disk.img"))),
+            .file(.init(path: try .init(validating: "hardware-model.bin"))),
+            .file(.init(path: try .init(validating: "machine-identifier.bin"))),
+            .file(.init(path: try .init(validating: "metadata.json"))),
         ])
         XCTAssertBundlesEqual(bundle, path: expectedBundlePath)
     }
@@ -257,7 +257,7 @@ final class ImageCacheTests: XCTestCase {
         ]
         let bundle = try fixtures.makeImageBundle(at: anyBundlePath)
         let expectedBundlePath = environment.currentWorkingDirectory.appending(component: ".curie-custom")
-            .appending(RelativePath(".images/\(anyReference)"))
+            .appending(try RelativePath(validating: ".images/\(anyReference)"))
 
         // When
         try subject.importImage(sourcePath: bundle.path.pathString, reference: anyReference)
@@ -265,12 +265,12 @@ final class ImageCacheTests: XCTestCase {
         // Then
         let files = try fileSystem.list(at: expectedBundlePath)
         XCTAssertEqual(files, [
-            .file(.init(path: .init("auxilary-storage.bin"))),
-            .file(.init(path: .init("config.json"))),
-            .file(.init(path: .init("disk.img"))),
-            .file(.init(path: .init("hardware-model.bin"))),
-            .file(.init(path: .init("machine-identifier.bin"))),
-            .file(.init(path: .init("metadata.json"))),
+            .file(.init(path: try .init(validating: "auxilary-storage.bin"))),
+            .file(.init(path: try .init(validating: "config.json"))),
+            .file(.init(path: try .init(validating: "disk.img"))),
+            .file(.init(path: try .init(validating: "hardware-model.bin"))),
+            .file(.init(path: try .init(validating: "machine-identifier.bin"))),
+            .file(.init(path: try .init(validating: "metadata.json"))),
         ])
         XCTAssertBundlesEqual(bundle, path: expectedBundlePath)
     }
@@ -278,7 +278,7 @@ final class ImageCacheTests: XCTestCase {
     func testExportImageRaw() throws {
         // Given
         let bundle = try fixtures.makeImageBundle(at: anyBundlePath)
-        let expectedBundlePath = environment.currentWorkingDirectory.appending(RelativePath("test/export"))
+        let expectedBundlePath = environment.currentWorkingDirectory.appending(try RelativePath(validating: "test/export"))
         try subject.importImage(sourcePath: bundle.path.pathString, reference: anyReference)
         let imageReference = try subject.findImageReference(anyReference)
 
@@ -292,12 +292,12 @@ final class ImageCacheTests: XCTestCase {
         // Then
         let files = try fileSystem.list(at: expectedBundlePath)
         XCTAssertEqual(files, [
-            .file(.init(path: .init("auxilary-storage.bin"))),
-            .file(.init(path: .init("config.json"))),
-            .file(.init(path: .init("disk.img"))),
-            .file(.init(path: .init("hardware-model.bin"))),
-            .file(.init(path: .init("machine-identifier.bin"))),
-            .file(.init(path: .init("metadata.json"))),
+            .file(.init(path: try .init(validating: "auxilary-storage.bin"))),
+            .file(.init(path: try .init(validating: "config.json"))),
+            .file(.init(path: try .init(validating: "disk.img"))),
+            .file(.init(path: try .init(validating: "hardware-model.bin"))),
+            .file(.init(path: try .init(validating: "machine-identifier.bin"))),
+            .file(.init(path: try .init(validating: "metadata.json"))),
         ])
         XCTAssertBundlesEqual(bundle, path: expectedBundlePath)
     }

--- a/Sources/CurieCoreTests/Cache/ImageCacheTests.swift
+++ b/Sources/CurieCoreTests/Cache/ImageCacheTests.swift
@@ -189,7 +189,9 @@ final class ImageCacheTests: XCTestCase {
 
     func testPath() throws {
         // Given
-        let expectedPath = environment.homeDirectory.appending(try RelativePath(validating: ".curie/.images/\(anyReference)"))
+        let expectedPath = try environment.homeDirectory.appending(
+            RelativePath(validating: ".curie/.images/\(anyReference)")
+        )
 
         // When
         let path = try subject.path(
@@ -207,20 +209,22 @@ final class ImageCacheTests: XCTestCase {
     func testImportImage() throws {
         // Given
         let bundle = try fixtures.makeImageBundle(at: anyBundlePath)
-        let expectedBundlePath = environment.homeDirectory.appending(try RelativePath(validating: ".curie/.images/\(anyReference)"))
+        let expectedBundlePath = try environment.homeDirectory.appending(
+            RelativePath(validating: ".curie/.images/\(anyReference)")
+        )
 
         // When
         try subject.importImage(sourcePath: bundle.path.pathString, reference: anyReference)
 
         // Then
         let files = try fileSystem.list(at: expectedBundlePath)
-        XCTAssertEqual(files, [
-            .file(.init(path: try .init(validating: "auxilary-storage.bin"))),
-            .file(.init(path: try .init(validating: "config.json"))),
-            .file(.init(path: try .init(validating: "disk.img"))),
-            .file(.init(path: try .init(validating: "hardware-model.bin"))),
-            .file(.init(path: try .init(validating: "machine-identifier.bin"))),
-            .file(.init(path: try .init(validating: "metadata.json"))),
+        XCTAssertEqual(files, try [
+            .file(.init(path: .init(validating: "auxilary-storage.bin"))),
+            .file(.init(path: .init(validating: "config.json"))),
+            .file(.init(path: .init(validating: "disk.img"))),
+            .file(.init(path: .init(validating: "hardware-model.bin"))),
+            .file(.init(path: .init(validating: "machine-identifier.bin"))),
+            .file(.init(path: .init(validating: "metadata.json"))),
         ])
         XCTAssertBundlesEqual(bundle, path: expectedBundlePath)
     }
@@ -231,21 +235,21 @@ final class ImageCacheTests: XCTestCase {
             "CURIE_DATA_ROOT": environment.temporaryDirectory.appending(component: ".curie-custom").pathString,
         ]
         let bundle = try fixtures.makeImageBundle(at: anyBundlePath)
-        let expectedBundlePath = environment.temporaryDirectory.appending(component: ".curie-custom")
-            .appending(try RelativePath(validating: ".images/\(anyReference)"))
+        let expectedBundlePath = try environment.temporaryDirectory.appending(component: ".curie-custom")
+            .appending(RelativePath(validating: ".images/\(anyReference)"))
 
         // When
         try subject.importImage(sourcePath: bundle.path.pathString, reference: anyReference)
 
         // Then
         let files = try fileSystem.list(at: expectedBundlePath)
-        XCTAssertEqual(files, [
-            .file(.init(path: try .init(validating: "auxilary-storage.bin"))),
-            .file(.init(path: try .init(validating: "config.json"))),
-            .file(.init(path: try .init(validating: "disk.img"))),
-            .file(.init(path: try .init(validating: "hardware-model.bin"))),
-            .file(.init(path: try .init(validating: "machine-identifier.bin"))),
-            .file(.init(path: try .init(validating: "metadata.json"))),
+        XCTAssertEqual(files, try [
+            .file(.init(path: .init(validating: "auxilary-storage.bin"))),
+            .file(.init(path: .init(validating: "config.json"))),
+            .file(.init(path: .init(validating: "disk.img"))),
+            .file(.init(path: .init(validating: "hardware-model.bin"))),
+            .file(.init(path: .init(validating: "machine-identifier.bin"))),
+            .file(.init(path: .init(validating: "metadata.json"))),
         ])
         XCTAssertBundlesEqual(bundle, path: expectedBundlePath)
     }
@@ -256,21 +260,21 @@ final class ImageCacheTests: XCTestCase {
             "CURIE_DATA_ROOT": ".curie-custom",
         ]
         let bundle = try fixtures.makeImageBundle(at: anyBundlePath)
-        let expectedBundlePath = environment.currentWorkingDirectory.appending(component: ".curie-custom")
-            .appending(try RelativePath(validating: ".images/\(anyReference)"))
+        let expectedBundlePath = try environment.currentWorkingDirectory.appending(component: ".curie-custom")
+            .appending(RelativePath(validating: ".images/\(anyReference)"))
 
         // When
         try subject.importImage(sourcePath: bundle.path.pathString, reference: anyReference)
 
         // Then
         let files = try fileSystem.list(at: expectedBundlePath)
-        XCTAssertEqual(files, [
-            .file(.init(path: try .init(validating: "auxilary-storage.bin"))),
-            .file(.init(path: try .init(validating: "config.json"))),
-            .file(.init(path: try .init(validating: "disk.img"))),
-            .file(.init(path: try .init(validating: "hardware-model.bin"))),
-            .file(.init(path: try .init(validating: "machine-identifier.bin"))),
-            .file(.init(path: try .init(validating: "metadata.json"))),
+        XCTAssertEqual(files, try [
+            .file(.init(path: .init(validating: "auxilary-storage.bin"))),
+            .file(.init(path: .init(validating: "config.json"))),
+            .file(.init(path: .init(validating: "disk.img"))),
+            .file(.init(path: .init(validating: "hardware-model.bin"))),
+            .file(.init(path: .init(validating: "machine-identifier.bin"))),
+            .file(.init(path: .init(validating: "metadata.json"))),
         ])
         XCTAssertBundlesEqual(bundle, path: expectedBundlePath)
     }
@@ -278,7 +282,9 @@ final class ImageCacheTests: XCTestCase {
     func testExportImageRaw() throws {
         // Given
         let bundle = try fixtures.makeImageBundle(at: anyBundlePath)
-        let expectedBundlePath = environment.currentWorkingDirectory.appending(try RelativePath(validating: "test/export"))
+        let expectedBundlePath = try environment.currentWorkingDirectory.appending(
+            RelativePath(validating: "test/export")
+        )
         try subject.importImage(sourcePath: bundle.path.pathString, reference: anyReference)
         let imageReference = try subject.findImageReference(anyReference)
 
@@ -291,13 +297,13 @@ final class ImageCacheTests: XCTestCase {
 
         // Then
         let files = try fileSystem.list(at: expectedBundlePath)
-        XCTAssertEqual(files, [
-            .file(.init(path: try .init(validating: "auxilary-storage.bin"))),
-            .file(.init(path: try .init(validating: "config.json"))),
-            .file(.init(path: try .init(validating: "disk.img"))),
-            .file(.init(path: try .init(validating: "hardware-model.bin"))),
-            .file(.init(path: try .init(validating: "machine-identifier.bin"))),
-            .file(.init(path: try .init(validating: "metadata.json"))),
+        XCTAssertEqual(files, try [
+            .file(.init(path: .init(validating: "auxilary-storage.bin"))),
+            .file(.init(path: .init(validating: "config.json"))),
+            .file(.init(path: .init(validating: "disk.img"))),
+            .file(.init(path: .init(validating: "hardware-model.bin"))),
+            .file(.init(path: .init(validating: "machine-identifier.bin"))),
+            .file(.init(path: .init(validating: "metadata.json"))),
         ])
         XCTAssertBundlesEqual(bundle, path: expectedBundlePath)
     }


### PR DESCRIPTION
Just fixes a bunch of warnings that `RelativePath(String)` is deprecated.