### PR TITLE
Expose --window or --no-window args

### DIFF
--- a/Sources/CurieCommand/Commands/RunCommand.swift
+++ b/Sources/CurieCommand/Commands/RunCommand.swift
@@ -30,8 +30,8 @@ struct RunCommand: Command {
     @Argument(help: "Reference \(CurieCore.Constants.referenceFormat).")
     var reference: String
 
-    @Flag(name: .shortAndLong, help: "Do not create window.")
-    var noWindow: Bool = false
+    @Flag(name: .customLong("window"), inversion: .prefixedNo, help: "Create window or not.")
+    var showWindow: Bool = true
 
     @Flag(name: .shortAndLong, help: "Start in recovery mode.")
     var recoveryMode: Bool = false
@@ -61,7 +61,7 @@ struct RunCommand: Command {
                 with: .init(
                     reference: command.reference,
                     launch: .init(
-                        noWindow: command.noWindow,
+                        showWindow: command.showWindow,
                         mainScreenResolution: command.mainScreenResolution,
                         recoveryMode: command.recoveryMode,
                         shareCurrentWorkingDirectory: command.shareCWD,

--- a/Sources/CurieCommand/Commands/StartCommand.swift
+++ b/Sources/CurieCommand/Commands/StartCommand.swift
@@ -30,8 +30,8 @@ struct StartCommand: Command {
     @Argument(help: "Reference \(CurieCore.Constants.referenceFormat).")
     var reference: String
 
-    @Flag(name: .shortAndLong, help: "Do not create window.")
-    var noWindow: Bool = false
+    @Flag(name: .customLong("window"), inversion: .prefixedNo, help: "Create window or not.")
+    var showWindow: Bool = true
 
     @Flag(name: .shortAndLong, help: "Pause on exit (requires macOS 14.0+).")
     var pauseOnExit: Bool = false
@@ -64,7 +64,7 @@ struct StartCommand: Command {
                 with: .init(
                     reference: command.reference,
                     launch: .init(
-                        noWindow: command.noWindow,
+                        showWindow: command.showWindow,
                         mainScreenResolution: command.mainScreenResolution,
                         recoveryMode: command.recoveryMode,
                         shareCurrentWorkingDirectory: command.shareCWD,

--- a/Sources/CurieCore/Interactors/Common/LaunchParameters.swift
+++ b/Sources/CurieCore/Interactors/Common/LaunchParameters.swift
@@ -19,20 +19,20 @@ import CurieCommon
 import Foundation
 
 public struct LaunchParameters {
-    public var noWindow: Bool
+    public var showWindow: Bool
     public var mainScreenResolution: Bool
     public var recoveryMode: Bool
     public var shareCurrentWorkingDirectory: Bool
     public var pauseOnExit: Bool
 
     public init(
-        noWindow: Bool,
+        showWindow: Bool,
         mainScreenResolution: Bool,
         recoveryMode: Bool,
         shareCurrentWorkingDirectory: Bool,
         pauseOnExit: Bool
     ) {
-        self.noWindow = noWindow
+        self.showWindow = showWindow
         self.mainScreenResolution = mainScreenResolution
         self.recoveryMode = recoveryMode
         self.shareCurrentWorkingDirectory = shareCurrentWorkingDirectory

--- a/Sources/CurieCore/Interactors/RunInteractor.swift
+++ b/Sources/CurieCore/Interactors/RunInteractor.swift
@@ -68,7 +68,7 @@ public final class DefaultRunInteractor: RunInteractor {
         let vm = try configurator.loadVM(with: bundle, overrideConfig: overrideConfig)
         let options = VMStartOptions(
             startUpFromMacOSRecovery: context.launch.recoveryMode,
-            noWindow: context.launch.noWindow
+            showWindow: context.launch.showWindow
         )
 
         vm.events

--- a/Sources/CurieCore/Interactors/StartInteractor.swift
+++ b/Sources/CurieCore/Interactors/StartInteractor.swift
@@ -66,7 +66,7 @@ public final class DefaultStartInteractor: StartInteractor {
         let vm = try configurator.loadVM(with: bundle, overrideConfig: overrideConfig)
         let options = VMStartOptions(
             startUpFromMacOSRecovery: context.launch.recoveryMode,
-            noWindow: context.launch.noWindow
+            showWindow: context.launch.showWindow
         )
 
         try imageRunner.run(vm: vm, bundle: bundle, options: options)

--- a/Sources/CurieCore/VM/ImageRunner.swift
+++ b/Sources/CurieCore/VM/ImageRunner.swift
@@ -88,12 +88,12 @@ final class DefaultImageRunner: ImageRunner {
         }
 
         // Launch interface
-        if options.noWindow {
-            console.text("Launch container without a window")
-            launchConsole(with: vm, bundle: bundle)
-        } else {
+        if options.showWindow {
             console.text("Launch container in a window")
             launchWindow(with: vm, bundle: bundle)
+        } else {
+            console.text("Launch container without a window")
+            launchConsole(with: vm, bundle: bundle)
         }
     }
 

--- a/Sources/CurieCore/VM/VM.swift
+++ b/Sources/CurieCore/VM/VM.swift
@@ -21,7 +21,7 @@ import Virtualization
 
 struct VMStartOptions {
     var startUpFromMacOSRecovery: Bool
-    var noWindow: Bool
+    var showWindow: Bool
 }
 
 final class VM: NSObject {


### PR DESCRIPTION
I just thought it would be nice to use the argparser's feature of value inversion using `--no` prefix which seems to be common thing among CLI tools.

```
./.build/debug/curie run -h                        
OVERVIEW: Start an ephemeral container.

USAGE: curie run <reference> [--window] [--no-window] [--recovery-mode] [--share-cwd] [--main-screen-resolution] [--quiet]

OPTIONS:
  --window/--no-window    Create window or not. (default: --window)
..
..
..

```