### PR TITLE
Fix `run` command cleanup

### DIFF
--- a/Sources/CurieCore/MacOSWindowApp/MacOSWindowAppLauncher.swift
+++ b/Sources/CurieCore/MacOSWindowApp/MacOSWindowAppLauncher.swift
@@ -73,6 +73,11 @@ private final class MacOSWindowAppDelegate: NSObject, NSApplicationDelegate, Obs
     func applicationDidFinishLaunching(_: Notification) {
         NSApplication.shared.mainMenu?.removeItem(at: indexOfEditMenu)
     }
+
+    func applicationShouldTerminate(_: NSApplication) -> NSApplication.TerminateReply {
+        MacOSWindowApp.vm.exit(machineStateURL: MacOSWindowApp.bundle.machineState.asURL, exit: exit)
+        return .terminateCancel
+    }
 }
 
 private struct MacOSWindowAppViewView: NSViewRepresentable {


### PR DESCRIPTION
The ephemeral container could stay in the local container cache after the process was closed via Menu > Exit. 

Test Plan:
- Ensure all CI checks pass
- Launch a container via run command with window and close it via menu, verify the container is no longer available (listed in `curie ps`) after the process terminates