### PR TITLE
Switch to Xcode 16.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  DEVELOPER_DIR: "/Applications/Xcode_16.0.app/Contents/Developer"
+  DEVELOPER_DIR: "/Applications/Xcode_16.2.app/Contents/Developer"
 
 # Limit GITHUB_TOKEN permissions to read-only for repo contents
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
 
 env:
-  DEVELOPER_DIR: "/Applications/Xcode_16.0.app/Contents/Developer"
+  DEVELOPER_DIR: "/Applications/Xcode_16.2.app/Contents/Developer"
 
 # Limit GITHUB_TOKEN permissions to read-only for repo contents
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication


### PR DESCRIPTION
Xcode 16.0 is no longer available in macos-14 image (https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md).

Test Plan:
- Ensure all CI checks pass