### PR TITLE
Fix `HTTP status client error (403 Forbidden)` CI errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   DEVELOPER_DIR: "/Applications/Xcode_16.2.app/Contents/Developer"
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 # Limit GITHUB_TOKEN permissions to read-only for repo contents
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   DEVELOPER_DIR: "/Applications/Xcode_16.2.app/Contents/Developer"
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 # Limit GITHUB_TOKEN permissions to read-only for repo contents
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
 
 env:
   DEVELOPER_DIR: "/Applications/Xcode_16.2.app/Contents/Developer"
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 # Limit GITHUB_TOKEN permissions to read-only for repo contents
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
 
 env:
   DEVELOPER_DIR: "/Applications/Xcode_16.2.app/Contents/Developer"
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 # Limit GITHUB_TOKEN permissions to read-only for repo contents
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication


### PR DESCRIPTION
It appears more and more builds fail due to issues with mise dependencies

```
mise ERROR failed to install aqua:realm/SwiftLint@0.57.0
mise ERROR HTTP status client error (403 Forbidden) for url (https://api.github.com/repos/realm/SwiftLint/releases/tags/0.57.0)
mise ERROR HTTP status client error (403 Forbidden) for url (https://api.github.com/repos/realm/SwiftLint/releases/tags/v0.57.0)
mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
make: *** [lint] Error 1
Error: Process completed with exit code 2.
```

The hypothesis is that it's due to GitHub API rate limiting (per IP)
https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28

This issue is also mentioned in mise documentation:
https://mise.jdx.dev/getting-started.html#github-api-rate-limiting

Test Plan:
- Ensure all CI checks pass