### PR TITLE
Set timeouts for CI jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
   lint:
     name: Lint
     runs-on: macos-14
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v4
     - name: Run setup
@@ -33,6 +34,7 @@ jobs:
   build:
     name: Build
     runs-on: macos-14
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v4
     - uses: actions/cache@v4
@@ -49,6 +51,7 @@ jobs:
   test:
     name: Test
     runs-on: macos-14
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v4
     - uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
   release:
     name: Release
     runs-on: macos-14
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Run setup


### PR DESCRIPTION
- 5 minutes for normal CI jobs (main, PRs)
- 10 minutes for release job

Test Plan:
- Ensure all CI checks pass